### PR TITLE
[T-F81C55] Change icons

### DIFF
--- a/client/src/KanbanBoard.jsx
+++ b/client/src/KanbanBoard.jsx
@@ -1,12 +1,19 @@
 import React, { useRef, useState, useEffect, useMemo } from 'react';
 import KanbanColumn from './KanbanColumn.jsx';
+import {
+  BacklogIcon,
+  PlanningIcon,
+  ImplementationIcon,
+  ReviewIcon,
+  DoneIcon,
+} from './KanbanIcons.jsx';
 
 const COLUMNS = [
-  { id: 'backlog',        title: 'Backlog',        icon: '\u25CB', statuses: ['backlog', 'paused', 'aborted'],  agentPrefix: null,   color: 'var(--text3)'  },
-  { id: 'planning',       title: 'Planning',       icon: '\u270E', statuses: ['workspace_setup', 'planning', 'awaiting_approval'], agentPrefix: 'plan', color: 'var(--steel2)' },
-  { id: 'implementation', title: 'Implementation', icon: '\u2692', statuses: ['queued', 'implementing'],        agentPrefix: 'imp',  color: 'var(--green)'  },
-  { id: 'review',         title: 'Review',         icon: '\u2714', statuses: ['review'],                        agentPrefix: 'rev',  color: 'var(--yellow)' },
-  { id: 'done',           title: 'Done',           icon: '\u2713', statuses: ['done'],                          agentPrefix: null,   color: 'var(--green)'  },
+  { id: 'backlog',        title: 'Backlog',        icon: <BacklogIcon />,        statuses: ['backlog', 'paused', 'aborted'],  agentPrefix: null,   color: 'var(--text3)'  },
+  { id: 'planning',       title: 'Planning',       icon: <PlanningIcon />,       statuses: ['workspace_setup', 'planning', 'awaiting_approval'], agentPrefix: 'plan', color: 'var(--steel2)' },
+  { id: 'implementation', title: 'Implementation', icon: <ImplementationIcon />, statuses: ['queued', 'implementing'],        agentPrefix: 'imp',  color: 'var(--green)'  },
+  { id: 'review',         title: 'Review',         icon: <ReviewIcon />,         statuses: ['review'],                        agentPrefix: 'rev',  color: 'var(--yellow)' },
+  { id: 'done',           title: 'Done',           icon: <DoneIcon />,           statuses: ['done'],                          agentPrefix: null,   color: 'var(--green)'  },
 ];
 
 export default function KanbanBoard({

--- a/client/src/KanbanColumn.jsx
+++ b/client/src/KanbanColumn.jsx
@@ -29,7 +29,17 @@ export default function KanbanColumn({
       <div style={{ padding: '12px 12px 8px', borderBottom: `2px solid ${column.color}30` }}>
         {/* Title row */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: columnAgents.length > 0 ? 8 : 0 }}>
-          <span style={{ fontSize: 14 }}>{column.icon}</span>
+          <span style={{
+            width: 16,
+            height: 16,
+            color: column.color,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            flexShrink: 0,
+          }}>
+            {column.icon}
+          </span>
           <span style={{
             fontFamily: 'var(--font-head)',
             fontWeight: 700,

--- a/client/src/KanbanIcons.jsx
+++ b/client/src/KanbanIcons.jsx
@@ -1,0 +1,93 @@
+import React from 'react';
+
+function BaseIcon({ children }) {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 16 16"
+      fill="none"
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  );
+}
+
+export function BacklogIcon() {
+  return (
+    <BaseIcon>
+      <circle cx="8" cy="8" r="4.75" stroke="currentColor" strokeWidth="1.5" opacity="0.8" />
+    </BaseIcon>
+  );
+}
+
+export function PlanningIcon() {
+  return (
+    <BaseIcon>
+      <path
+        d="M4 11.5L11.8 3.7C12.3 3.2 13.1 3.2 13.6 3.7C14.1 4.2 14.1 5 13.6 5.5L5.8 13.3L3 14L3.7 11.2L9.2 5.7"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </BaseIcon>
+  );
+}
+
+export function ImplementationIcon() {
+  return (
+    <BaseIcon>
+      <path
+        d="M5.5 4L2.5 8L5.5 12"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M10.5 4L13.5 8L10.5 12"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M8.9 3.2L7.1 12.8"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </BaseIcon>
+  );
+}
+
+export function ReviewIcon() {
+  return (
+    <BaseIcon>
+      <circle cx="7" cy="7" r="3.5" stroke="currentColor" strokeWidth="1.5" />
+      <path
+        d="M9.7 9.7L13 13"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+      />
+    </BaseIcon>
+  );
+}
+
+export function DoneIcon() {
+  return (
+    <BaseIcon>
+      <circle cx="8" cy="8" r="5.25" stroke="currentColor" strokeWidth="1.5" />
+      <path
+        d="M5.4 8.1L7.2 9.9L10.8 6.3"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </BaseIcon>
+  );
+}


### PR DESCRIPTION
## Summary

Replace the kanban board’s hardcoded Unicode column icons with clearer, visually distinct local SVG icons so Implementation, Review, and Done each communicate a different stage.

## Key Changes

- client/src/KanbanBoard.jsx (replace hardcoded Unicode glyphs in `COLUMNS` with references to clearer icon components)
- client/src/KanbanColumn.jsx (ensure column headers render SVG icons with consistent sizing, alignment, and color)
- client/src/KanbanIcons.jsx (new file to hold reusable local SVG icon components for kanban stages, avoiding a new dependency)

## Validation

- Run `npm run build --prefix client` to catch JSX/import/runtime issues after introducing the local icon module.
- Manual UI check in `http://localhost:5173` to confirm each kanban column shows the intended icon and that Review and Done are clearly different at normal dashboard scale.

## Review

- Verdict: PASS
- Summary: The branch cleanly replaces the hardcoded Unicode glyphs with local SVG components and keeps the change scoped to the kanban header rendering path. I found no correctness, security, or maintainability issues in the diff; the only remaining validation is the planned client build and manual UI check to confirm the icons read clearly at runtime.

## Risks

- New SVG icons may look too thin or indistinct at the current small header size, requiring minor sizing or stroke-width tuning in `client/src/KanbanColumn.jsx`.
- If `column.icon` is assumed elsewhere to be a string, converting it to React nodes could expose hidden rendering assumptions; verify usage stays limited to the board header path.