### PR TITLE
[T-EFBFE8] Change the icons

### DIFF
--- a/client/src/KanbanBoard.jsx
+++ b/client/src/KanbanBoard.jsx
@@ -1,12 +1,90 @@
 import React, { useRef, useState, useEffect, useMemo } from 'react';
 import KanbanColumn from './KanbanColumn.jsx';
 
+function StageIcon({ children }) {
+  return (
+    <svg
+      viewBox='0 0 16 16'
+      aria-hidden='true'
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'block',
+      }}
+    >
+      {children}
+    </svg>
+  );
+}
+
 const COLUMNS = [
-  { id: 'backlog',        title: 'Backlog',        icon: '\u25CB', statuses: ['backlog', 'paused', 'aborted'],  agentPrefix: null,   color: 'var(--text3)'  },
-  { id: 'planning',       title: 'Planning',       icon: '\u270E', statuses: ['workspace_setup', 'planning', 'awaiting_approval'], agentPrefix: 'plan', color: 'var(--steel2)' },
-  { id: 'implementation', title: 'Implementation', icon: '\u2692', statuses: ['queued', 'implementing'],        agentPrefix: 'imp',  color: 'var(--green)'  },
-  { id: 'review',         title: 'Review',         icon: '\u2714', statuses: ['review'],                        agentPrefix: 'rev',  color: 'var(--yellow)' },
-  { id: 'done',           title: 'Done',           icon: '\u2713', statuses: ['done'],                          agentPrefix: null,   color: 'var(--green)'  },
+  {
+    id: 'backlog',
+    title: 'Backlog',
+    icon: (
+      <StageIcon>
+        <rect x='2.5' y='3' width='11' height='10' rx='2' fill='none' stroke='currentColor' strokeWidth='1.5' />
+        <path d='M5 6h6M5 8.5h6M5 11h3.5' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1.5' />
+      </StageIcon>
+    ),
+    statuses: ['backlog', 'paused', 'aborted'],
+    agentPrefix: null,
+    color: 'var(--text3)',
+  },
+  {
+    id: 'planning',
+    title: 'Planning',
+    icon: (
+      <StageIcon>
+        <path d='M4 12.5h2.25l5.75-5.75-2.25-2.25L4 10.25v2.25Z' fill='none' stroke='currentColor' strokeLinejoin='round' strokeWidth='1.5' />
+        <path d='M8.75 5.75 11 8' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1.5' />
+        <path d='M3.5 13h9' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1.5' />
+      </StageIcon>
+    ),
+    statuses: ['workspace_setup', 'planning', 'awaiting_approval'],
+    agentPrefix: 'plan',
+    color: 'var(--steel2)',
+  },
+  {
+    id: 'implementation',
+    title: 'Implementation',
+    icon: (
+      <StageIcon>
+        <path d='m6.25 4.5 1.25-1.25 5 5L11.25 9.5l-.9-.9-1.6 1.6a1.5 1.5 0 0 1-2.12 0l-.83-.83a1.5 1.5 0 0 1 0-2.12l1.6-1.6-.9-.9Z' fill='none' stroke='currentColor' strokeLinejoin='round' strokeWidth='1.5' />
+        <path d='M4 12.25 7.5 8.75' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1.5' />
+        <path d='m3.5 10.5 2 2' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1.5' />
+      </StageIcon>
+    ),
+    statuses: ['queued', 'implementing'],
+    agentPrefix: 'imp',
+    color: 'var(--green)',
+  },
+  {
+    id: 'review',
+    title: 'Review',
+    icon: (
+      <StageIcon>
+        <path d='M1.75 8s2.25-3.75 6.25-3.75S14.25 8 14.25 8 12 11.75 8 11.75 1.75 8 1.75 8Z' fill='none' stroke='currentColor' strokeLinejoin='round' strokeWidth='1.5' />
+        <circle cx='8' cy='8' r='1.75' fill='none' stroke='currentColor' strokeWidth='1.5' />
+      </StageIcon>
+    ),
+    statuses: ['review'],
+    agentPrefix: 'rev',
+    color: 'var(--yellow)',
+  },
+  {
+    id: 'done',
+    title: 'Done',
+    icon: (
+      <StageIcon>
+        <circle cx='8' cy='8' r='5.25' fill='none' stroke='currentColor' strokeWidth='1.5' />
+        <path d='m5.5 8 1.5 1.5 3.5-3.5' fill='none' stroke='currentColor' strokeLinecap='round' strokeLinejoin='round' strokeWidth='1.5' />
+      </StageIcon>
+    ),
+    statuses: ['done'],
+    agentPrefix: null,
+    color: 'var(--green)',
+  },
 ];
 
 export default function KanbanBoard({

--- a/client/src/KanbanColumn.jsx
+++ b/client/src/KanbanColumn.jsx
@@ -29,7 +29,17 @@ export default function KanbanColumn({
       <div style={{ padding: '12px 12px 8px', borderBottom: `2px solid ${column.color}30` }}>
         {/* Title row */}
         <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: columnAgents.length > 0 ? 8 : 0 }}>
-          <span style={{ fontSize: 14 }}>{column.icon}</span>
+          <span style={{
+            width: 16,
+            height: 16,
+            display: 'inline-flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            color: column.color,
+            flexShrink: 0,
+          }}>
+            {column.icon}
+          </span>
           <span style={{
             fontFamily: 'var(--font-head)',
             fontWeight: 700,


### PR DESCRIPTION
## Summary

Replace the kanban column header glyphs with a clearer, more polished icon set so each stage is visually distinct, especially `review` versus `done`.

## Key Changes

- client/src/KanbanBoard.jsx (replace the current hardcoded Unicode column icons with a more intentional per-column icon definition)
- client/src/KanbanColumn.jsx (update header icon rendering/styles so the new icons display consistently in size, alignment, and color)

## Validation

- Manual UI verification in `npm run dev --prefix client`: confirm all column headers render the new icons correctly
- Manual regression check that `review` and `done` are visually distinct and no header layout shifts or clipping occur

## Review

- Verdict: PASS
- Summary: Changed files reviewed: `client/src/KanbanBoard.jsx`, `client/src/KanbanColumn.jsx`. The implementation is appropriately scoped, preserves the existing column/status routing behavior, and the new SVG-based icons are clearer and more maintainable than the prior hardcoded Unicode glyphs. I did not find branch-introduced correctness issues; the only notable gap is missing verification for a UI-only change where regressions would be visual rather than functional.
- Minor issues: Confidence 84: `client/src/KanbanBoard.jsx:4` and `client/src/KanbanColumn.jsx:32` introduce a rendering change from text glyphs to inline SVG React nodes, but the branch includes no automated coverage and no recorded manual verification for the header layout. This matters because the risk here is visual regression rather than logic failure, and issues like clipping, misalignment, or inconsistent sizing across populated and empty columns would not be caught otherwise. Concrete fix: run the planned manual UI checks in the dashboard and note the result in the PR, or add a lightweight render test/screenshot test around the column header if the repo is starting to add UI tests.

## Risks

- Inline SVG/icon-node rendering requires a small change in `KanbanColumn.jsx`; if `column.icon` is left text-only, React will render inconsistently or styling will be limited
- If icon sizing is not normalized, different SVG shapes can make headers look misaligned even when the icons are technically distinct