### PR TITLE
[T-7C5074] PR Template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,45 @@
+## Summary
+
+Briefly describe what changed and why.
+
+## Related Issue or Task
+
+Link the relevant issue, discussion, or task ID.
+
+Examples:
+- `Closes #123`
+- `Task: T-1234`
+
+## User-Visible Impact
+
+What should a user, reviewer, or maintainer notice after this change?
+
+If there is no visible impact, say so.
+
+## Setup or Config Impact
+
+List any setup, environment, or configuration changes required for this PR.
+
+If none, say `None`.
+
+## Verification
+
+Describe the checks you ran. Manual verification is fine if that is the relevant validation for this change.
+
+Examples:
+- `npm run build`
+- Started the app with `npm run dev` and verified the new flow manually
+- No automated tests were added for this change
+
+## Screenshots
+
+Add screenshots, recordings, or before/after images for UI changes when relevant.
+
+If not applicable, say `N/A`.
+
+## Checklist
+
+- [ ] I linked the related issue or task ID
+- [ ] I documented the verification I performed
+- [ ] I updated docs or config notes if this change requires it
+- [ ] I added screenshots if this PR changes the UI


### PR DESCRIPTION
## Summary

Add a repository-level GitHub pull request template that matches the repo’s existing contribution guidance and issue template tone.

## Key Changes

- .github/pull_request_template.md (add the default GitHub PR template used when contributors open a PR)

## Validation

- Manual review of `.github/pull_request_template.md` for Markdown structure, clarity, and alignment with current contribution guidance
- Optional GitHub UI verification by opening the “new pull request” flow and confirming the template auto-populates

## Review

- Verdict: PASS
- Summary: Changed files reviewed: `.github/pull_request_template.md`. The template is otherwise well aligned with `README.md`, `AGENTS.md`, and the issue-template tone: it stays concise, emphasizes task/issue linkage, and explicitly supports manual verification in a repo without a broad automated test suite. The only issue I found is the screenshot checklist item reading as mandatory when the surrounding guidance says it is optional for non-UI work.
- Minor issues: `.github/pull_request_template.md:45` makes screenshots look like a required checkbox even for non-UI PRs. That conflicts with the rest of the template and the repo guidance, which treat screenshots as conditional, and it will leave many legitimate backend or docs PRs looking artificially incomplete. Concrete fix: change the line to something explicitly conditional such as `- [ ] If this PR changes the UI, I added screenshots` or replace it with plain helper text instead of a checkbox. Confidence: 84/100.

## Risks

- The template can become noisy if it includes too many mandatory-looking sections for a repo with lightweight contribution guidance
- Overstating testing expectations would conflict with the current repository state, which relies primarily on manual verification