### PR TITLE
[T-02F771] Icons

### DIFF
--- a/client/src/KanbanBoard.jsx
+++ b/client/src/KanbanBoard.jsx
@@ -23,8 +23,8 @@ const COLUMNS = [
     title: 'Backlog',
     icon: (
       <StageIcon>
-        <rect x='2.5' y='3' width='11' height='10' rx='2' fill='none' stroke='currentColor' strokeWidth='1.5' />
-        <path d='M5 6h6M5 8.5h6M5 11h3.5' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1.5' />
+        <path d='M4 3.5h8c0.83 0 1.5 0.67 1.5 1.5v6c0 0.83-0.67 1.5-1.5 1.5h-8c-0.83 0-1.5-0.67-1.5-1.5v-6c0-0.83 0.67-1.5 1.5-1.5Z' fill='none' stroke='currentColor' strokeLinecap='round' strokeLinejoin='round' strokeWidth='1.2' />
+        <path d='M5 7h6M5 10h4' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1' />
       </StageIcon>
     ),
     statuses: ['backlog', 'paused', 'aborted'],
@@ -36,9 +36,8 @@ const COLUMNS = [
     title: 'Planning',
     icon: (
       <StageIcon>
-        <path d='M4 12.5h2.25l5.75-5.75-2.25-2.25L4 10.25v2.25Z' fill='none' stroke='currentColor' strokeLinejoin='round' strokeWidth='1.5' />
-        <path d='M8.75 5.75 11 8' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1.5' />
-        <path d='M3.5 13h9' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1.5' />
+        <path d='M3.5 4h9c0.83 0 1.5 0.67 1.5 1.5v7c0 0.83-0.67 1.5-1.5 1.5h-9c-0.83 0-1.5-0.67-1.5-1.5v-7c0-0.83 0.67-1.5 1.5-1.5Z' fill='none' stroke='currentColor' strokeLinecap='round' strokeLinejoin='round' strokeWidth='1.2' />
+        <path d='M5.5 7h3M5.5 9.5h5M5.5 12h3' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1' />
       </StageIcon>
     ),
     statuses: ['workspace_setup', 'planning', 'awaiting_approval'],
@@ -50,9 +49,8 @@ const COLUMNS = [
     title: 'Implementation',
     icon: (
       <StageIcon>
-        <path d='m6.25 4.5 1.25-1.25 5 5L11.25 9.5l-.9-.9-1.6 1.6a1.5 1.5 0 0 1-2.12 0l-.83-.83a1.5 1.5 0 0 1 0-2.12l1.6-1.6-.9-.9Z' fill='none' stroke='currentColor' strokeLinejoin='round' strokeWidth='1.5' />
-        <path d='M4 12.25 7.5 8.75' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1.5' />
-        <path d='m3.5 10.5 2 2' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1.5' />
+        <path d='M2 6.5L6 3l4 3.5M2 6.5v4c0 0.83 0.67 1.5 1.5 1.5h9c0.83 0 1.5-0.67 1.5-1.5v-4' fill='none' stroke='currentColor' strokeLinecap='round' strokeLinejoin='round' strokeWidth='1.2' />
+        <path d='M8 8v3.5' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1' />
       </StageIcon>
     ),
     statuses: ['queued', 'implementing'],
@@ -64,8 +62,8 @@ const COLUMNS = [
     title: 'Review',
     icon: (
       <StageIcon>
-        <path d='M1.75 8s2.25-3.75 6.25-3.75S14.25 8 14.25 8 12 11.75 8 11.75 1.75 8 1.75 8Z' fill='none' stroke='currentColor' strokeLinejoin='round' strokeWidth='1.5' />
-        <circle cx='8' cy='8' r='1.75' fill='none' stroke='currentColor' strokeWidth='1.5' />
+        <circle cx='8' cy='8' r='4.5' fill='none' stroke='currentColor' strokeLinecap='round' strokeLinejoin='round' strokeWidth='1.2' />
+        <path d='M6 8l1.5 1.5 2.5-2.5' fill='none' stroke='currentColor' strokeLinecap='round' strokeLinejoin='round' strokeWidth='1.2' />
       </StageIcon>
     ),
     statuses: ['review'],
@@ -77,8 +75,8 @@ const COLUMNS = [
     title: 'Done',
     icon: (
       <StageIcon>
-        <circle cx='8' cy='8' r='5.25' fill='none' stroke='currentColor' strokeWidth='1.5' />
-        <path d='m5.5 8 1.5 1.5 3.5-3.5' fill='none' stroke='currentColor' strokeLinecap='round' strokeLinejoin='round' strokeWidth='1.5' />
+        <path d='M3 3h10c0.83 0 1.5 0.67 1.5 1.5v7c0 0.83-0.67 1.5-1.5 1.5H3c-0.83 0-1.5-0.67-1.5-1.5v-7c0-0.83 0.67-1.5 1.5-1.5Z' fill='none' stroke='currentColor' strokeLinecap='round' strokeLinejoin='round' strokeWidth='1.2' />
+        <path d='M5 8.5l1.5 2 3.5-4' fill='none' stroke='currentColor' strokeLinecap='round' strokeLinejoin='round' strokeWidth='1.2' />
       </StageIcon>
     ),
     statuses: ['done'],


### PR DESCRIPTION
## Summary

Replace the SVG icons for the five Kanban stage columns (Backlog, Planning, Implementation, Review, Done)

## Key Changes

- client/src/KanbanBoard.jsx (update icon definitions in the COLUMNS array, lines 24-87)

## Validation

- Verify visual rendering in browser (icon display, color inheritance, alignment)
- Run existing test suite to confirm no regressions

## Review

- Verdict: PASS
- Summary: The icon changes are technically sound—all SVG paths render within the 16×16 viewBox, use stroke='currentColor'   for proper color inheritance, pass linting, and maintain the column color scheme unchanged. The only concern is the      Review stage icon now looks like "approved" rather than "review," which could confuse the stage purpose. Visual  verification in the browser is recommended to confirm rendering and color inheritance match expectations before merging.
- Minor issues: Review stage icon semantic mismatch (lines 65-66): The new Review icon displays a circle with a checkmark, which        visually represents "approved/done" rather than "review/examination." The original eye icon conveyed the Review stage  purpose more clearly. Since the Done stage now also shows a checkmark (in a rounded rectangle), users may be confused    about the distinction between Review and Done stages. Both icons use stroke rendering and color inheritance correctly,; Review stage icon semantic mismatch (lines 65-66): The new Review icon displays a circle with a checkmark, which visually represents "approved/done" rather than "review/examinat on." The original eye icon conveyed the Review stage purpose more cl arly. Since the Done s age now also shows   checkmark (in a rou ded r ctangle), us rs may be confused about the distinction betw en Review and Do e stages. Both i ons use stroke endering and color inherit nce correctly, but consider reverti g to an icon that better repr ents code review emantics.

## Risks

- SVG paths with incorrect viewBox proportions may render too large or distorted; validate path dimensions are optimized   for 16x16 canvas
- If icons use fill instead of stroke, they won't inherit currentColor properly
- Oversized or asymmetric icons may misalign in the header flex layout; keep padding and sizing consistent with original   icons                                                                                                                     ❯  X
- SVG paths with incorrect viewBox proportions may render too large or distorted; validate path dimensions are optimized for 16x16 canvasX         X                         X               X              - If icons use fill instead of stroke, they won't inherit currentColor properlyOversized or asymmetric ic ns may misalign i   he  ader flex layout; keep padding and sizing consistent with original icons         X                                                                       X