### PR TITLE
[T-8588E5] Review cycles

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -555,6 +555,7 @@ function SettingsModal({ settings, onClose, onApply }) {
       const range = maxRules[role] || { min: 1, max: 10 };
       return cfg.max >= range.min && cfg.max <= range.max;
     }) &&
+    typeof local.maxReviewCycles === 'number' && local.maxReviewCycles >= 1 && local.maxReviewCycles <= 20 &&
     ['planning', 'implementation', 'review'].every(stage => typeof local.prompts?.[stage] === 'string');
 
   const tabs = [
@@ -654,6 +655,40 @@ function SettingsModal({ settings, onClose, onApply }) {
             {cfgMeta.description}
           </div>
         </div>
+
+        {stage === 'review' && (
+          <div style={{ marginBottom: 20 }}>
+            <div style={{
+              fontSize: 11, fontWeight: 600, color: 'var(--text2)',
+              letterSpacing: 1, marginBottom: 10,
+            }}>
+              REVIEW CYCLES
+            </div>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 8 }}>
+              <span style={{ fontSize: 12, color: 'var(--text2)', width: 130 }}>Max review cycles:</span>
+              <input
+                type="number"
+                min={1}
+                max={20}
+                data-testid="max-review-cycles"
+                value={local.maxReviewCycles ?? 3}
+                onChange={e => {
+                  const parsed = parseInt(e.target.value, 10);
+                  const clamped = Number.isNaN(parsed) ? 1 : Math.max(1, Math.min(20, parsed));
+                  setLocal(prev => ({ ...prev, maxReviewCycles: clamped }));
+                }}
+                style={{
+                  width: 60, padding: '4px 6px', fontSize: 12,
+                  background: 'var(--bg)', border: '1px solid var(--border)',
+                  borderRadius: 4, textAlign: 'center',
+                }}
+              />
+            </div>
+            <div style={{ fontSize: 10, color: 'var(--text3)' }}>
+              Maximum review-fix iterations before a task is blocked for human input.
+            </div>
+          </div>
+        )}
 
         <div style={{ marginBottom: 18 }}>
           <div style={{

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -69,6 +69,7 @@ describe('App', () => {
         defaultRepoPath: '/repo-b',
         workspaceRoot: '/tmp/original',
         repos: ['/repo-a', '/repo-b'],
+        maxReviewCycles: 3,
         agents: {
           planners: { max: 1, cli: 'claude', model: '' },
           implementors: { max: 2, cli: 'codex', model: '' },
@@ -204,6 +205,7 @@ describe('App', () => {
       defaultRepoPath: '/repo-a',
       workspaceRoot: '/tmp/restored',
       repos: ['/repo-a'],
+      maxReviewCycles: 3,
       agents: {
         planners: { max: 1, cli: 'claude', model: '' },
         implementors: { max: 2, cli: 'codex', model: '' },
@@ -243,6 +245,7 @@ describe('App', () => {
       defaultRepoPath: '/repo-b',
       workspaceRoot: '/tmp/workspaces',
       repos: ['/repo-b', '/repo-c'],
+      maxReviewCycles: 3,
       agents: {
         planners: { max: 3, cli: 'codex', model: '' },
         implementors: { max: 2, cli: 'codex', model: '' },
@@ -254,5 +257,23 @@ describe('App', () => {
         review: 'Review prompt',
       },
     });
+  });
+
+  test('renders max review cycles input in Review tab and updates local state', () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByTitle('Settings'));
+    fireEvent.click(screen.getByText('Review'));
+
+    const cyclesInput = screen.getByTestId('max-review-cycles');
+    expect(cyclesInput).toBeTruthy();
+    expect(cyclesInput.value).toBe('3');
+
+    fireEvent.change(cyclesInput, { target: { value: '5' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(factoryState.updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ maxReviewCycles: 5 })
+    );
   });
 });

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -136,6 +136,7 @@ export function getDefaults() {
       implementors: { max: 8, cli: getLegacyImplementorCli(), model: '' },
       reviewers:    { max: 4, cli: 'claude', model: '' },
     },
+    maxReviewCycles: 3,
     prompts: { ...DEFAULT_PROMPTS },
   };
 }
@@ -168,6 +169,10 @@ function normalizeSettingsShape(data) {
         data.agents[role].model = '';
       }
     }
+  }
+
+  if (typeof data.maxReviewCycles !== 'number' || data.maxReviewCycles < 1) {
+    data.maxReviewCycles = defaults.maxReviewCycles;
   }
 
   data.prompts = {
@@ -237,6 +242,10 @@ export function validateSettings(settings) {
     } else if (typeof cfg.model === 'string' && validClis.includes(cfg.cli) && !isValidModelForCli(cfg.cli, cfg.model)) {
       errors.push(`${role}.model '${cfg.model}' is not valid for the '${cfg.cli}' CLI`);
     }
+  }
+
+  if (typeof settings.maxReviewCycles !== 'number' || settings.maxReviewCycles < 1 || settings.maxReviewCycles > 20) {
+    errors.push('maxReviewCycles must be a number between 1 and 20');
   }
 
   if (!settings.prompts || typeof settings.prompts !== 'object') {

--- a/server/src/config.test.js
+++ b/server/src/config.test.js
@@ -76,6 +76,53 @@ describe('config settings lifecycle', () => {
     expect(errors).toContain('prompts.review must be a string');
   });
 
+  test('getDefaults includes maxReviewCycles and normalizeSettingsShape corrects invalid values', async () => {
+    harness = createRuntimeHarness();
+    const configModule = await harness.importModule('./src/config.js');
+
+    const defaults = configModule.getDefaults();
+    expect(defaults.maxReviewCycles).toBe(3);
+
+    configModule.saveSettings({
+      ...defaults,
+      maxReviewCycles: -5,
+    });
+    const loaded = configModule.loadSettings();
+    expect(loaded.maxReviewCycles).toBe(3);
+
+    configModule.saveSettings({
+      ...defaults,
+      maxReviewCycles: 'bad',
+    });
+    expect(configModule.loadSettings().maxReviewCycles).toBe(3);
+
+    configModule.saveSettings({
+      ...defaults,
+      maxReviewCycles: 10,
+    });
+    expect(configModule.loadSettings().maxReviewCycles).toBe(10);
+  });
+
+  test('validateSettings rejects out-of-range maxReviewCycles', async () => {
+    harness = createRuntimeHarness();
+    const { validateSettings, getDefaults } = await harness.importModule('./src/config.js');
+    const base = {
+      ...getDefaults(),
+      repos: ['/repo'],
+      defaultRepoPath: '/repo',
+      workspaceRoot: '/tmp/ws',
+    };
+
+    expect(validateSettings({ ...base, maxReviewCycles: 0 }))
+      .toContain('maxReviewCycles must be a number between 1 and 20');
+    expect(validateSettings({ ...base, maxReviewCycles: 21 }))
+      .toContain('maxReviewCycles must be a number between 1 and 20');
+    expect(validateSettings({ ...base, maxReviewCycles: 'bad' }))
+      .toContain('maxReviewCycles must be a number between 1 and 20');
+    expect(validateSettings({ ...base, maxReviewCycles: 5 }))
+      .not.toContain('maxReviewCycles must be a number between 1 and 20');
+  });
+
   test('reads env defaults for repos, port, and legacy implementor cli', async () => {
     harness = createRuntimeHarness();
     const { writeFileSync } = await import('node:fs');
@@ -135,6 +182,7 @@ describe('config settings lifecycle', () => {
       repos: ['/repo'],
       defaultRepoPath: '/repo',
       workspaceRoot: '/tmp/ws',
+      maxReviewCycles: 3,
       agents: {
         planners: { max: 1, cli: 'claude', model: 'claude-haiku-4-5' },
         implementors: { max: 1, cli: 'claude', model: 'claude-opus-4-6' },
@@ -158,6 +206,7 @@ describe('config settings lifecycle', () => {
       repos: ['/repo'],
       defaultRepoPath: '/repo',
       workspaceRoot: '/tmp/ws',
+      maxReviewCycles: 3,
       agents: {
         planners: { max: 1, cli: 'codex', model: 'claude-haiku-4-5' },
         implementors: { max: 1, cli: 'claude', model: 'gpt-5.4' },
@@ -179,6 +228,7 @@ describe('config settings lifecycle', () => {
       repos: ['/repo'],
       defaultRepoPath: '/repo',
       workspaceRoot: '/tmp/ws',
+      maxReviewCycles: 3,
       agents: {
         planners: { max: 1, cli: 'codex', model: 'gpt-5.3-codex' },
         implementors: { max: 1, cli: 'codex', model: 'gpt-5.4' },

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -24,7 +24,9 @@ const PLANNER_TIMEOUT = 5 * 60 * 1000;
 const IMPLEMENTOR_TIMEOUT = 60 * 60 * 1000;
 const REVIEWER_TIMEOUT = 30 * 60 * 1000;
 const STUCK_TIMEOUT = 10 * 60 * 1000;
-const DEFAULT_MAX_REVIEW_CYCLES = 3;
+function getMaxReviewCycles() {
+  return loadSettings().maxReviewCycles || 3;
+}
 
 let pollTimer = null;
 let signalTimer = null;
@@ -789,7 +791,7 @@ async function startPlanning(task) {
       review: null,
       reviewFeedback: null,
       reviewCycleCount: 0,
-      maxReviewCycles: resolveTaskMaxReviewCycles(task, DEFAULT_MAX_REVIEW_CYCLES),
+      maxReviewCycles: resolveTaskMaxReviewCycles(task, getMaxReviewCycles()),
       blockedReason: null,
       assignedTo: null,
     });
@@ -870,7 +872,7 @@ function onPlanComplete(agentId, taskId) {
     review: null,
     reviewFeedback: null,
     reviewCycleCount: 0,
-    maxReviewCycles: resolveTaskMaxReviewCycles(task, DEFAULT_MAX_REVIEW_CYCLES),
+    maxReviewCycles: resolveTaskMaxReviewCycles(task, getMaxReviewCycles()),
     blockedReason: null,
     assignedTo: null,
   });
@@ -1051,7 +1053,7 @@ async function onReviewComplete(agentId, taskId) {
 
     const task = store.getTask(taskId);
     const nextReviewCycleCount = (task?.reviewCycleCount || 0) + 1;
-    const maxReviewCycles = Math.max(1, task?.maxReviewCycles || DEFAULT_MAX_REVIEW_CYCLES);
+    const maxReviewCycles = Math.max(1, task?.maxReviewCycles || getMaxReviewCycles());
 
     if (nextReviewCycleCount >= maxReviewCycles) {
       store.updateTask(taskId, {
@@ -1171,7 +1173,7 @@ async function abortTask(taskId) {
     reviewFeedback: null,
     previousStatus: null,
     reviewCycleCount: 0,
-    maxReviewCycles: DEFAULT_MAX_REVIEW_CYCLES,
+    maxReviewCycles: getMaxReviewCycles(),
   });
 
   bus.emit('task:aborted', { taskId });
@@ -1203,7 +1205,7 @@ async function resetTask(taskId) {
     planFeedback: null,
     previousStatus: null,
     reviewCycleCount: 0,
-    maxReviewCycles: DEFAULT_MAX_REVIEW_CYCLES,
+    maxReviewCycles: getMaxReviewCycles(),
     sessionHistory: [],
     progress: 0,
     totalTokens: 0,

--- a/server/src/store.js
+++ b/server/src/store.js
@@ -2,7 +2,7 @@ import { mkdirSync, readFileSync, writeFileSync, existsSync, rmSync } from 'node
 import { join } from 'node:path';
 import { v4 as uuidv4 } from 'uuid';
 import bus from './events.js';
-import { getRuntimeStatePaths } from './config.js';
+import { getRuntimeStatePaths, loadSettings } from './config.js';
 
 const runtimePaths = getRuntimeStatePaths();
 const DATA_DIR = runtimePaths.dataDir;
@@ -42,6 +42,10 @@ function isLegacyPlannerPathBlocker(task) {
   return false;
 }
 
+function getDefaultMaxReviewCycles() {
+  return loadSettings().maxReviewCycles || 3;
+}
+
 class TaskStore {
   constructor() {
     this.tasks = [];
@@ -61,7 +65,7 @@ class TaskStore {
         this.tasks = this.tasks.map(task => {
           const normalized = {
             reviewCycleCount: 0,
-            maxReviewCycles: 3,
+            maxReviewCycles: getDefaultMaxReviewCycles(),
             lastActiveStage: statusToStage(task.status) || 'backlog',
             previousStatus: null,
             totalTokens: 0,
@@ -82,7 +86,7 @@ class TaskStore {
             normalized.reviewCycleCount = 0;
           }
           if (typeof normalized.maxReviewCycles !== 'number' || normalized.maxReviewCycles < 1) {
-            normalized.maxReviewCycles = 3;
+            normalized.maxReviewCycles = getDefaultMaxReviewCycles();
           }
           if (typeof normalized.totalTokens !== 'number' || normalized.totalTokens < 0) {
             normalized.totalTokens = 0;
@@ -134,7 +138,7 @@ class TaskStore {
       blockedReason: null,
       workspacePath: null,
       reviewCycleCount: 0,
-      maxReviewCycles: 3,
+      maxReviewCycles: getDefaultMaxReviewCycles(),
       lastActiveStage: 'backlog',
       previousStatus: null,
       totalTokens: 0,
@@ -251,7 +255,7 @@ class TaskStore {
         changed = true;
       }
       if (typeof task.maxReviewCycles !== 'number' || task.maxReviewCycles < 1) {
-        task.maxReviewCycles = 3;
+        task.maxReviewCycles = getDefaultMaxReviewCycles();
         changed = true;
       }
       if (typeof task.totalTokens !== 'number' || task.totalTokens < 0) {


### PR DESCRIPTION
## Summary

Add a configurable maxReviewCycles setting to the global settings so users can control the default number of review cycles instead of the hardcoded 3.

## Key Changes

- server/src/config.js (add maxReviewCycles to defaults, normalization, and validation)
- server/src/config.test.js (add tests for the new setting field)
- server/src/orchestrator.js (read maxReviewCycles from settings instead of hardcoded constant)
- server/src/store.js (use settings-based default when normalizing tasks instead of hardcoded 3)
- server/src/store.test.js (update expectations to reflect settings-based default)
- client/src/App.jsx (add maxReviewCycles number input to the Review tab in SettingsModal)

## Review

- Verdict: PASS
- Summary: Changed files: server/src/config.js, server/src/config.test.js, server/src/orchestrator.js, server/src/store.js, client/src/App.jsx, client/src/App.test.jsx, plus lockfile churn. The implementation cleanly  replaces all hardcoded DEFAULT_MAX_REVIEW_CYCLES = 3 references with a settings-backed function, adds proper validation/normalization in config, and wires up a well-styled UI input in the Review settings tab. Tests      cover defaults, invalid-value correction, out-of-range validation, and the UI round-trip. The approach is consistent with the existing codebase patterns (inline styles, loadSettings() usage, resolveTaskMaxReviewCycles  fallback chain) and the commit is well-scoped to the feature.
- Minor issues: [Confidence: 82] loadSettings() called on every task normalization during store load — store.js:45 getDefaultMaxReviewCycles() calls loadSettings() which reads and parses config.json from disk. During  _sanitizeOnLoad() this is called once per task in the array (lines 65, 86, 255). For large task lists this means repeated disk reads. Consider caching the value once at the top of _sanitizeOnLoad() and passing it down   instead of calling loadSettings() per-task. Same applies to orchestrator.js:getMaxReviewCycles() but those call sites are infrequent (per-event), so the impact is negligible there.; [Confidence: 78] Clamping on input masks invalid intermediate typing — App.jsx:676 the onChange handler immediately clamps the parsed value to [1, 20]. This means a user trying to type 15 will see 1 after the first  keystroke (which is correct), but if they clear the field entirely, parseInt('', 10) is NaN → clamped to 1. This prevents the user from clearing the field to type a new number. A common UX pattern is to defer            validation to blur/submit and allow free typing in the input. Minor polish issue.; [Confidence: 77] normalizeSettingsShape does not enforce the upper bound — config.js:174 only checks < 1, so a value of 999 passes normalization and is stored. validateSettings correctly rejects > 20, but  normalization and validation are inconsistent — normalization is the last line of defense when loading from disk, while validation gates the UI save path. If someone hand-edits config.json with a value like 50, it will   be loaded as-is. Consider adding || data.maxReviewCycles > 20 to the normalization guard to match the validation rule.