### PR TITLE
[T-76B7E2] Cleanup aborted tasks

### DIFF
--- a/client/src/TaskDetailModal.jsx
+++ b/client/src/TaskDetailModal.jsx
@@ -666,7 +666,7 @@ export default function TaskDetailModal({
                 </button>
               )}
 
-              {task.status === 'done' && onDelete && (
+              {(task.status === 'done' || task.status === 'aborted') && onDelete && (
                 <button
                   onClick={() => {
                     if (confirmDelete) {
@@ -682,7 +682,7 @@ export default function TaskDetailModal({
                     borderRadius: 4, color: 'var(--red)',
                   }}
                 >
-                  {confirmDelete ? 'Confirm Delete' : 'Delete from Done'}
+                  {confirmDelete ? 'Confirm Delete' : task.status === 'aborted' ? 'Delete Task' : 'Delete from Done'}
                 </button>
               )}
             </div>
@@ -710,9 +710,9 @@ export default function TaskDetailModal({
               </div>
             )}
 
-            {confirmDelete && task.status === 'done' && (
+            {confirmDelete && (task.status === 'done' || task.status === 'aborted') && (
               <div style={{ marginTop: 10, fontSize: 10, color: 'var(--text3)', lineHeight: 1.5 }}>
-                Delete removes the completed task from Ban Kan state and clears any saved plan/workspace artifacts.
+                Delete removes the {task.status === 'aborted' ? 'aborted' : 'completed'} task from Ban Kan state and clears any saved plan/workspace artifacts.
               </div>
             )}
           </>

--- a/client/src/TaskDetailModal.test.jsx
+++ b/client/src/TaskDetailModal.test.jsx
@@ -165,4 +165,22 @@ describe('TaskDetailModal', () => {
     expect(onAllowMoreReview).toHaveBeenCalledWith('T-1');
     expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull();
   });
+
+  test('renders delete button when task status is aborted', () => {
+    const onDelete = vi.fn();
+    render(
+      <TaskDetailModal
+        task={buildTask({ status: 'aborted', blockedReason: null, reviewCycleCount: 0 })}
+        onClose={() => {}}
+        onAbort={() => {}}
+        onReset={() => {}}
+        onRetry={() => {}}
+        onDelete={onDelete}
+        onOpenWorkspace={() => {}}
+      />
+    );
+
+    const deleteBtn = screen.getByRole('button', { name: 'Delete Task' });
+    expect(deleteBtn).toBeTruthy();
+  });
 });

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -175,7 +175,7 @@ app.patch('/api/tasks/:id/extend-max-review-blocker', (req, res) => {
 app.delete('/api/tasks/:id', async (req, res) => {
   const task = store.getTask(req.params.id);
   if (!task) return res.status(404).json({ error: 'Task not found' });
-  if (task.status !== 'done') return res.status(400).json({ error: 'Only completed tasks can be deleted' });
+  if (!['done', 'aborted'].includes(task.status)) return res.status(400).json({ error: 'Only completed or aborted tasks can be deleted' });
   await orchestrator.deleteTask(task.id);
   broadcast('TASK_DELETED', { taskId: task.id });
   res.json({ ok: true });
@@ -585,7 +585,7 @@ wss.on('connection', (ws) => {
       case 'DELETE_TASK': {
         const { taskId } = msg.payload || {};
         const task = store.getTask(taskId);
-        if (task?.status === 'done') {
+        if (task?.status === 'done' || task?.status === 'aborted') {
           orchestrator.deleteTask(taskId);
           broadcast('TASK_DELETED', { taskId });
         }

--- a/server/src/orchestrator.delete.test.js
+++ b/server/src/orchestrator.delete.test.js
@@ -1,0 +1,95 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const getTask = vi.fn();
+const deleteTaskStore = vi.fn();
+const removePlan = vi.fn();
+const appendLog = vi.fn();
+
+vi.mock('./store.js', () => ({
+  default: {
+    getTask,
+    deleteTask: deleteTaskStore,
+    removePlan,
+    appendLog,
+    updateTask: vi.fn(),
+    restartRecovery: vi.fn(),
+    getAllTasks: vi.fn(() => []),
+  },
+}));
+
+vi.mock('./events.js', () => ({
+  default: {
+    emit: vi.fn(),
+    on: vi.fn(),
+  },
+}));
+
+vi.mock('./agents.js', () => ({
+  default: {
+    get: vi.fn(),
+    getAvailablePlanner: vi.fn(),
+    getAvailableImplementor: vi.fn(),
+    getAvailableReviewer: vi.fn(),
+    getAllStatus: vi.fn(() => []),
+    agents: new Map(),
+    reconfigure: vi.fn(),
+  },
+}));
+
+vi.mock('./config.js', () => ({
+  loadSettings: vi.fn(() => ({
+    agents: {
+      planners: { max: 1 },
+      implementors: { max: 1 },
+      reviewers: { max: 1 },
+    },
+  })),
+  getWorkspacesDir: vi.fn(() => '/tmp/workspaces'),
+}));
+
+vi.mock('simple-git', () => ({
+  simpleGit: vi.fn(() => ({})),
+}));
+
+const orchestrator = (await import('./orchestrator.js')).default;
+const deleteTask = orchestrator.deleteTask;
+
+describe('deleteTask', () => {
+  beforeEach(() => {
+    getTask.mockReset();
+    deleteTaskStore.mockReset();
+    removePlan.mockReset();
+  });
+
+  test('succeeds for a task with status done', async () => {
+    getTask.mockReturnValue({ id: 'T-1', status: 'done', workspacePath: null });
+    const result = await deleteTask('T-1');
+    expect(result).toBe(true);
+    expect(removePlan).toHaveBeenCalledWith('T-1');
+    expect(deleteTaskStore).toHaveBeenCalledWith('T-1');
+  });
+
+  test('succeeds for a task with status aborted', async () => {
+    getTask.mockReturnValue({ id: 'T-2', status: 'aborted', workspacePath: null });
+    const result = await deleteTask('T-2');
+    expect(result).toBe(true);
+    expect(removePlan).toHaveBeenCalledWith('T-2');
+    expect(deleteTaskStore).toHaveBeenCalledWith('T-2');
+  });
+
+  test('rejects tasks in non-terminal statuses', async () => {
+    for (const status of ['backlog', 'planning', 'implementing', 'review', 'blocked']) {
+      getTask.mockReturnValue({ id: 'T-3', status, workspacePath: null });
+      const result = await deleteTask('T-3');
+      expect(result).toBe(false);
+      expect(deleteTaskStore).not.toHaveBeenCalled();
+      deleteTaskStore.mockReset();
+    }
+  });
+
+  test('returns false when task does not exist', async () => {
+    getTask.mockReturnValue(undefined);
+    const result = await deleteTask('T-999');
+    expect(result).toBe(false);
+  });
+});

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -1217,7 +1217,7 @@ async function resetTask(taskId) {
 
 async function deleteTask(taskId) {
   const task = store.getTask(taskId);
-  if (!task || task.status !== 'done') return false;
+  if (!task || !['done', 'aborted'].includes(task.status)) return false;
 
   if (task.workspacePath) {
     await cleanupWorkspace(task);


### PR DESCRIPTION
## Summary

Allow deletion of aborted tasks by relaxing the existing delete-task validation to accept both 'done' and 'aborted' statuses.

## Key Changes

- server/src/orchestrator.js (allow 'aborted' status in deleteTask validation)
- server/src/index.js (allow 'aborted' in REST endpoint and WebSocket handler validations)
- client/src/TaskDetailModal.jsx (show delete button for aborted tasks, update label/text)

## Validation

- Add test in server test suite: deleteTask still rejects tasks in non-terminal statuses (backlog, planning, implementing, etc.)
- Add test in client test suite: TaskDetailModal renders delete button when task status is 'aborted'

## Review

- Verdict: PASS
- Summary: Changed files: server/src/orchestrator.js, server/src/index.js, client/src/TaskDetailModal.jsx, server/src/orchestrator.delete.test.js, client/src/TaskDetailModal.test.jsx (plus package-lock churn). The change   is minimal and surgical — it relaxes the delete-task guard from 'done'-only to ['done', 'aborted'] across the orchestrator, REST endpoint, WebSocket handler, and UI, with context-aware button labels. Tests cover done,   aborted, non-terminal statuses, and missing tasks. The implementation follows existing patterns consistently and the scope is appropriately contained.

## Risks

- Aborted tasks may still have workspace directories on disk; the existing orchestrator.deleteTask already handles workspace cleanup, and the abort flow also cleans up workspaces, so this should be safe (double-cleanup is a no-op).
- Add test in server test suite: deleteTask succeeds for a task with status 'aborted' till rejects tasks in non-termin l s atuses (backlog, planning, implementing, etc.) client TaskD t ilModa  rend rs delete butt  when t sk status is 'aborted'                             RISKS:                                                                                               - Aborted tasks may still have workspace directories on disk; the existing orchestrator.deleteTask already handles workspace cleanup, and the abort flow also cleans up workspaces, so this should be safe (double-cleanup is a no-op).