### PR TITLE
[T-A355AA] Autopilot mode

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -931,12 +931,8 @@ function SettingsModal({ settings, onClose, onApply }) {
                   ].map((opt, i, arr) => {
                     const isSelected = (local.autopilotMode || 'manual') === opt.value;
                     return (
-                      <button
+                      <label
                         key={opt.value}
-                        type="button"
-                        role="radio"
-                        aria-checked={isSelected}
-                        onClick={() => setLocal(prev => ({ ...prev, autopilotMode: opt.value }))}
                         style={{
                           flex: 1,
                           padding: '7px 10px',
@@ -950,10 +946,19 @@ function SettingsModal({ settings, onClose, onApply }) {
                           borderRadius: i === 0 ? '4px 0 0 4px' : i === arr.length - 1 ? '0 4px 4px 0' : 0,
                           cursor: 'pointer',
                           borderRightWidth: i < arr.length - 1 ? 0 : 1,
+                          textAlign: 'center',
                         }}
                       >
+                        <input
+                          type="radio"
+                          name="executionMode"
+                          value={opt.value}
+                          checked={isSelected}
+                          onChange={() => setLocal(prev => ({ ...prev, autopilotMode: opt.value }))}
+                          style={{ position: 'absolute', opacity: 0, pointerEvents: 'none' }}
+                        />
                         {opt.label}
-                      </button>
+                      </label>
                     );
                   })}
                 </div>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -188,6 +188,18 @@ export default function App() {
         >
           {'\u2699'}
         </button>
+        {(settings?.autopilotMode === 'autopilot' || settings?.autopilotMode === 'hybrid') && (
+          <span
+            data-testid="mode-badge"
+            style={{
+              fontSize: 9, fontWeight: 700, letterSpacing: 0.5,
+              padding: '2px 6px', borderRadius: 3,
+              background: 'var(--amber)', color: '#000',
+            }}
+          >
+            {settings.autopilotMode.toUpperCase()}
+          </span>
+        )}
 
         {/* Add Task */}
         <button
@@ -579,11 +591,14 @@ function SettingsModal({ settings, onClose, onApply }) {
   };
 
   const isValid = Boolean(local.workspaceRoot?.trim()) &&
-    Object.entries(local.agents || {}).every(([role, cfg]) => {
-      const range = maxRules[role] || { min: 1, max: 10 };
-      return cfg.max >= range.min && cfg.max <= range.max;
-    }) &&
+    Object.entries(local.agents || {})
+      .filter(([role]) => role !== 'supervisor')
+      .every(([role, cfg]) => {
+        const range = maxRules[role] || { min: 1, max: 10 };
+        return cfg.max >= range.min && cfg.max <= range.max;
+      }) &&
     typeof local.maxReviewCycles === 'number' && local.maxReviewCycles >= 1 && local.maxReviewCycles <= 20 &&
+    (local.maxPlanRejections === undefined || (typeof local.maxPlanRejections === 'number' && local.maxPlanRejections >= 1 && local.maxPlanRejections <= 10)) &&
     ['manual', 'autopilot', 'hybrid'].includes(local.autopilotMode || 'manual') &&
     ['planning', 'implementation', 'review'].every(stage => typeof local.prompts?.[stage] === 'string');
 
@@ -967,6 +982,69 @@ function SettingsModal({ settings, onClose, onApply }) {
                   {local.autopilotMode === 'hybrid' && 'AI supervisor auto-approves plans. Review failures use standard auto-retry.'}
                   {local.autopilotMode === 'autopilot' && 'Fully automated: AI supervisor approves plans and makes smart retry decisions on review failures. Escalates only when stuck.'}
                 </div>
+                {(local.autopilotMode === 'hybrid' || local.autopilotMode === 'autopilot') && (
+                  <div style={{ marginTop: 12 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+                      <span style={{ fontSize: 12, color: 'var(--text2)', width: 100 }}>Supervisor model:</span>
+                      <select
+                        data-testid="model-select-supervisor"
+                        value={encodeCliModel(
+                          local.agents?.supervisor?.cli || 'claude',
+                          local.agents?.supervisor?.model || ''
+                        )}
+                        onChange={e => {
+                          const { cli, model } = decodeCliModel(e.target.value);
+                          setLocal(prev => {
+                            const next = JSON.parse(JSON.stringify(prev));
+                            next.agents.supervisor = { cli, model };
+                            return next;
+                          });
+                        }}
+                        style={{
+                          flex: 1, padding: '4px 8px', fontSize: 12,
+                          background: 'var(--bg)', border: '1px solid var(--border)',
+                          borderRadius: 4,
+                        }}
+                      >
+                        {Object.entries(CLI_MODEL_MAP).map(([cli, models]) => (
+                          <optgroup key={cli} label={`${cli} CLI`}>
+                            {models.map(opt => (
+                              <option key={encodeCliModel(cli, opt.value)} value={encodeCliModel(cli, opt.value)}>
+                                {opt.label}
+                              </option>
+                            ))}
+                          </optgroup>
+                        ))}
+                      </select>
+                    </div>
+                    <div style={{ fontSize: 10, color: 'var(--text3)', marginTop: 4 }}>
+                      CLI and model used by the AI supervisor for plan evaluation and review-failure triage.
+                    </div>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 10 }}>
+                      <span style={{ fontSize: 12, color: 'var(--text2)', width: 100 }}>Max rejections:</span>
+                      <input
+                        type="number"
+                        min={1}
+                        max={10}
+                        data-testid="max-plan-rejections"
+                        value={local.maxPlanRejections ?? 3}
+                        onChange={e => {
+                          const parsed = parseInt(e.target.value, 10);
+                          const val = Number.isNaN(parsed) ? 3 : Math.max(1, Math.min(10, parsed));
+                          setLocal(prev => ({ ...prev, maxPlanRejections: val }));
+                        }}
+                        style={{
+                          width: 60, padding: '4px 6px', fontSize: 12,
+                          background: 'var(--bg)', border: '1px solid var(--border)',
+                          borderRadius: 4, textAlign: 'center',
+                        }}
+                      />
+                    </div>
+                    <div style={{ fontSize: 10, color: 'var(--text3)', marginTop: 4 }}>
+                      Plans rejected more than this many times are escalated to human review.
+                    </div>
+                  </div>
+                )}
               </div>
 
               <div style={{ fontSize: 11, color: 'var(--text3)', marginBottom: 16, fontStyle: 'italic' }}>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -584,6 +584,7 @@ function SettingsModal({ settings, onClose, onApply }) {
       return cfg.max >= range.min && cfg.max <= range.max;
     }) &&
     typeof local.maxReviewCycles === 'number' && local.maxReviewCycles >= 1 && local.maxReviewCycles <= 20 &&
+    ['manual', 'autopilot', 'hybrid'].includes(local.autopilotMode || 'manual') &&
     ['planning', 'implementation', 'review'].every(stage => typeof local.prompts?.[stage] === 'string');
 
   const tabs = [
@@ -914,6 +915,47 @@ function SettingsModal({ settings, onClose, onApply }) {
                   </div>
                 </div>
               )}
+
+              <div style={{ marginBottom: 20 }}>
+                <div style={{
+                  fontSize: 11, fontWeight: 600, color: 'var(--text2)',
+                  letterSpacing: 1, marginBottom: 8,
+                }}>
+                  EXECUTION MODE
+                </div>
+                <div style={{ display: 'flex', gap: 0, marginBottom: 8 }}>
+                  {[
+                    { value: 'manual', label: 'Manual' },
+                    { value: 'hybrid', label: 'Hybrid' },
+                    { value: 'autopilot', label: 'Autopilot' },
+                  ].map((opt, i, arr) => (
+                    <button
+                      key={opt.value}
+                      onClick={() => setLocal(prev => ({ ...prev, autopilotMode: opt.value }))}
+                      style={{
+                        flex: 1,
+                        padding: '7px 10px',
+                        fontSize: 12,
+                        fontWeight: 600,
+                        background: (local.autopilotMode || 'manual') === opt.value ? 'var(--amber)' : 'var(--bg2)',
+                        color: (local.autopilotMode || 'manual') === opt.value ? '#000' : 'var(--text2)',
+                        border: '1px solid',
+                        borderColor: (local.autopilotMode || 'manual') === opt.value ? 'var(--amber)' : 'var(--border)',
+                        borderRadius: i === 0 ? '4px 0 0 4px' : i === arr.length - 1 ? '0 4px 4px 0' : 0,
+                        cursor: 'pointer',
+                        borderRight: i < arr.length - 1 ? 'none' : undefined,
+                      }}
+                    >
+                      {opt.label}
+                    </button>
+                  ))}
+                </div>
+                <div style={{ fontSize: 10, color: 'var(--text3)' }}>
+                  {(local.autopilotMode || 'manual') === 'manual' && 'Human approves all plans and handles review failures.'}
+                  {local.autopilotMode === 'hybrid' && 'AI supervisor auto-approves plans. Review failures use standard auto-retry.'}
+                  {local.autopilotMode === 'autopilot' && 'Fully automated: AI supervisor approves plans and makes smart retry decisions on review failures. Escalates only when stuck.'}
+                </div>
+              </div>
 
               <div style={{ fontSize: 11, color: 'var(--text3)', marginBottom: 16, fontStyle: 'italic' }}>
                 Orchestrator scales agents up on demand, up to the max per role. Planning and Review can be disabled by setting max to 0.

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -923,32 +923,39 @@ function SettingsModal({ settings, onClose, onApply }) {
                 }}>
                   EXECUTION MODE
                 </div>
-                <div style={{ display: 'flex', gap: 0, marginBottom: 8 }}>
+                <div role="radiogroup" aria-label="Execution mode" style={{ display: 'flex', gap: 0, marginBottom: 8 }}>
                   {[
                     { value: 'manual', label: 'Manual' },
                     { value: 'hybrid', label: 'Hybrid' },
                     { value: 'autopilot', label: 'Autopilot' },
-                  ].map((opt, i, arr) => (
-                    <button
-                      key={opt.value}
-                      onClick={() => setLocal(prev => ({ ...prev, autopilotMode: opt.value }))}
-                      style={{
-                        flex: 1,
-                        padding: '7px 10px',
-                        fontSize: 12,
-                        fontWeight: 600,
-                        background: (local.autopilotMode || 'manual') === opt.value ? 'var(--amber)' : 'var(--bg2)',
-                        color: (local.autopilotMode || 'manual') === opt.value ? '#000' : 'var(--text2)',
-                        border: '1px solid',
-                        borderColor: (local.autopilotMode || 'manual') === opt.value ? 'var(--amber)' : 'var(--border)',
-                        borderRadius: i === 0 ? '4px 0 0 4px' : i === arr.length - 1 ? '0 4px 4px 0' : 0,
-                        cursor: 'pointer',
-                        borderRight: i < arr.length - 1 ? 'none' : undefined,
-                      }}
-                    >
-                      {opt.label}
-                    </button>
-                  ))}
+                  ].map((opt, i, arr) => {
+                    const isSelected = (local.autopilotMode || 'manual') === opt.value;
+                    return (
+                      <button
+                        key={opt.value}
+                        type="button"
+                        role="radio"
+                        aria-checked={isSelected}
+                        onClick={() => setLocal(prev => ({ ...prev, autopilotMode: opt.value }))}
+                        style={{
+                          flex: 1,
+                          padding: '7px 10px',
+                          fontSize: 12,
+                          fontWeight: 600,
+                          background: isSelected ? 'var(--amber)' : 'var(--bg2)',
+                          color: isSelected ? '#000' : 'var(--text2)',
+                          borderStyle: 'solid',
+                          borderWidth: 1,
+                          borderColor: isSelected ? 'var(--amber)' : 'var(--border)',
+                          borderRadius: i === 0 ? '4px 0 0 4px' : i === arr.length - 1 ? '0 4px 4px 0' : 0,
+                          cursor: 'pointer',
+                          borderRightWidth: i < arr.length - 1 ? 0 : 1,
+                        }}
+                      >
+                        {opt.label}
+                      </button>
+                    );
+                  })}
                 </div>
                 <div style={{ fontSize: 10, color: 'var(--text3)' }}>
                   {(local.autopilotMode || 'manual') === 'manual' && 'Human approves all plans and handles review failures.'}

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -294,4 +294,16 @@ describe('App', () => {
     expect(screen.getByRole('radio', { name: 'Autopilot' }).getAttribute('aria-checked')).toBe('true');
     expect(screen.getByRole('radio', { name: 'Manual' }).getAttribute('aria-checked')).toBe('false');
   });
+
+  test('Apply sends autopilotMode in updateSettings payload', () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByTitle('Settings'));
+    fireEvent.click(screen.getByRole('radio', { name: 'Autopilot' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(factoryState.updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ autopilotMode: 'autopilot' })
+    );
+  });
 });

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -276,4 +276,22 @@ describe('App', () => {
       expect.objectContaining({ maxReviewCycles: 5 })
     );
   });
+
+  test('exposes execution mode as an accessible radio group with the selected mode announced', () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByTitle('Settings'));
+
+    const group = screen.getByRole('radiogroup', { name: 'Execution mode' });
+    expect(group).toBeTruthy();
+
+    expect(screen.getByRole('radio', { name: 'Manual' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('radio', { name: 'Hybrid' }).getAttribute('aria-checked')).toBe('false');
+    expect(screen.getByRole('radio', { name: 'Autopilot' }).getAttribute('aria-checked')).toBe('false');
+
+    fireEvent.click(screen.getByRole('radio', { name: 'Autopilot' }));
+
+    expect(screen.getByRole('radio', { name: 'Autopilot' }).getAttribute('aria-checked')).toBe('true');
+    expect(screen.getByRole('radio', { name: 'Manual' }).getAttribute('aria-checked')).toBe('false');
+  });
 });

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -285,14 +285,14 @@ describe('App', () => {
     const group = screen.getByRole('radiogroup', { name: 'Execution mode' });
     expect(group).toBeTruthy();
 
-    expect(screen.getByRole('radio', { name: 'Manual' }).getAttribute('aria-checked')).toBe('true');
-    expect(screen.getByRole('radio', { name: 'Hybrid' }).getAttribute('aria-checked')).toBe('false');
-    expect(screen.getByRole('radio', { name: 'Autopilot' }).getAttribute('aria-checked')).toBe('false');
+    expect(screen.getByRole('radio', { name: 'Manual' }).checked).toBe(true);
+    expect(screen.getByRole('radio', { name: 'Hybrid' }).checked).toBe(false);
+    expect(screen.getByRole('radio', { name: 'Autopilot' }).checked).toBe(false);
 
     fireEvent.click(screen.getByRole('radio', { name: 'Autopilot' }));
 
-    expect(screen.getByRole('radio', { name: 'Autopilot' }).getAttribute('aria-checked')).toBe('true');
-    expect(screen.getByRole('radio', { name: 'Manual' }).getAttribute('aria-checked')).toBe('false');
+    expect(screen.getByRole('radio', { name: 'Autopilot' }).checked).toBe(true);
+    expect(screen.getByRole('radio', { name: 'Manual' }).checked).toBe(false);
   });
 
   test('Apply sends autopilotMode in updateSettings payload', () => {

--- a/client/src/App.test.jsx
+++ b/client/src/App.test.jsx
@@ -74,6 +74,7 @@ describe('App', () => {
           planners: { max: 1, cli: 'claude', model: '' },
           implementors: { max: 2, cli: 'codex', model: '' },
           reviewers: { max: 1, cli: 'claude', model: '' },
+          supervisor: { cli: 'claude', model: '' },
         },
         prompts: {
           planning: 'Plan prompt',
@@ -210,6 +211,7 @@ describe('App', () => {
         planners: { max: 1, cli: 'claude', model: '' },
         implementors: { max: 2, cli: 'codex', model: '' },
         reviewers: { max: 1, cli: 'claude', model: '' },
+        supervisor: { cli: 'claude', model: '' },
       },
       prompts: {
         planning: 'Plan prompt',
@@ -250,6 +252,7 @@ describe('App', () => {
         planners: { max: 3, cli: 'codex', model: '' },
         implementors: { max: 2, cli: 'codex', model: '' },
         reviewers: { max: 1, cli: 'claude', model: '' },
+        supervisor: { cli: 'claude', model: '' },
       },
       prompts: {
         planning: 'Updated plan prompt',
@@ -295,6 +298,47 @@ describe('App', () => {
     expect(screen.getByRole('radio', { name: 'Manual' }).checked).toBe(false);
   });
 
+  test('supervisor model selector is hidden in manual mode and visible in autopilot/hybrid', () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByTitle('Settings'));
+
+    // Manual mode: no supervisor selector
+    expect(screen.queryByTestId('model-select-supervisor')).toBeNull();
+
+    // Switch to Hybrid: selector appears
+    fireEvent.click(screen.getByRole('radio', { name: 'Hybrid' }));
+    expect(screen.getByTestId('model-select-supervisor')).toBeTruthy();
+
+    // Switch to Autopilot: still visible
+    fireEvent.click(screen.getByRole('radio', { name: 'Autopilot' }));
+    expect(screen.getByTestId('model-select-supervisor')).toBeTruthy();
+
+    // Switch back to Manual: hidden again
+    fireEvent.click(screen.getByRole('radio', { name: 'Manual' }));
+    expect(screen.queryByTestId('model-select-supervisor')).toBeNull();
+  });
+
+  test('supervisor model change is included in Apply payload', () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByTitle('Settings'));
+    fireEvent.click(screen.getByRole('radio', { name: 'Autopilot' }));
+
+    fireEvent.change(screen.getByTestId('model-select-supervisor'), {
+      target: { value: 'claude:claude-haiku-4-5' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(factoryState.updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agents: expect.objectContaining({
+          supervisor: { cli: 'claude', model: 'claude-haiku-4-5' },
+        }),
+      })
+    );
+  });
+
   test('Apply sends autopilotMode in updateSettings payload', () => {
     render(<App />);
 
@@ -304,6 +348,45 @@ describe('App', () => {
 
     expect(factoryState.updateSettings).toHaveBeenCalledWith(
       expect.objectContaining({ autopilotMode: 'autopilot' })
+    );
+  });
+
+  test('shows mode badge in header when autopilot or hybrid is active', () => {
+    factoryState.settings.autopilotMode = 'autopilot';
+    render(<App />);
+    const badge = screen.getByTestId('mode-badge');
+    expect(badge.textContent).toBe('AUTOPILOT');
+
+    // Re-render with hybrid
+    factoryState.settings.autopilotMode = 'hybrid';
+    const { unmount } = render(<App />);
+    expect(screen.getAllByTestId('mode-badge')[1].textContent).toBe('HYBRID');
+    unmount();
+  });
+
+  test('hides mode badge in manual mode', () => {
+    factoryState.settings.autopilotMode = 'manual';
+    render(<App />);
+    expect(screen.queryByTestId('mode-badge')).toBeNull();
+  });
+
+  test('maxPlanRejections input appears in autopilot mode and is included in Apply', () => {
+    render(<App />);
+
+    fireEvent.click(screen.getByTitle('Settings'));
+    // Not visible in manual mode
+    expect(screen.queryByTestId('max-plan-rejections')).toBeNull();
+
+    // Switch to Autopilot
+    fireEvent.click(screen.getByRole('radio', { name: 'Autopilot' }));
+    const input = screen.getByTestId('max-plan-rejections');
+    expect(input).toBeTruthy();
+
+    fireEvent.change(input, { target: { value: '5' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Apply' }));
+
+    expect(factoryState.updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({ maxPlanRejections: 5 })
     );
   });
 });

--- a/client/src/TaskDetailModal.jsx
+++ b/client/src/TaskDetailModal.jsx
@@ -70,7 +70,10 @@ function formatTotalTime(startedAt, completedAt) {
 
 function isMaxReviewCyclesBlocker(blockedReason) {
   if (typeof blockedReason !== 'string') return false;
-  return /^Reached maximum review cycles(?: \(\d+\))?/i.test(blockedReason.trim());
+  const trimmed = blockedReason.trim();
+  return /^Reached maximum review cycles(?: \(\d+\))?/i.test(trimmed)
+    || /^Supervisor exhausted \d+ extension/i.test(trimmed)
+    || /^Supervisor escalated/i.test(trimmed);
 }
 
 export default function TaskDetailModal({

--- a/client/src/TaskDetailModal.jsx
+++ b/client/src/TaskDetailModal.jsx
@@ -380,6 +380,37 @@ export default function TaskDetailModal({
               </div>
             )}
 
+            {/* Supervisor Feedback */}
+            {task.planFeedback && (
+              <div style={{ marginBottom: 14 }}>
+                <div style={{
+                  ...labelStyle, display: 'flex', alignItems: 'center', gap: 8,
+                }}>
+                  Supervisor Feedback
+                  {task.planRejectionCount > 0 && (
+                    <span style={{
+                      fontSize: 10, color: 'var(--amber)',
+                      fontWeight: 400,
+                    }}>
+                      (rejected {task.planRejectionCount}{task.maxPlanRejections ? `/${task.maxPlanRejections}` : ''})
+                    </span>
+                  )}
+                </div>
+                <pre style={{
+                  fontSize: 11, color: 'var(--text2)',
+                  background: 'var(--bg)', padding: 10, borderRadius: 4,
+                  whiteSpace: 'pre-wrap', wordBreak: 'break-word',
+                  maxHeight: 200, overflowY: 'auto',
+                  borderLeft: '3px solid var(--amber)',
+                  border: '1px solid var(--border)',
+                  borderLeftColor: 'var(--amber)',
+                  borderLeftWidth: 3,
+                }}>
+                  {task.planFeedback}
+                </pre>
+              </div>
+            )}
+
             {/* Review (collapsible) */}
             {task.review && (
               <div style={{ marginBottom: 14 }}>

--- a/client/src/TaskDetailModal.test.jsx
+++ b/client/src/TaskDetailModal.test.jsx
@@ -183,4 +183,35 @@ describe('TaskDetailModal', () => {
     const deleteBtn = screen.getByRole('button', { name: 'Delete Task' });
     expect(deleteBtn).toBeTruthy();
   });
+
+  test('displays supervisor feedback with rejection count when planFeedback exists', () => {
+    render(
+      <TaskDetailModal
+        task={buildTask({
+          status: 'awaiting_approval',
+          plan: 'Some plan content',
+          planFeedback: 'Missing implementation steps for the auth module.',
+          planRejectionCount: 2,
+          maxPlanRejections: 3,
+        })}
+        repos={['/repo']}
+        onClose={vi.fn()}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onPause={vi.fn()}
+        onResume={vi.fn()}
+        onEdit={vi.fn()}
+        onAbort={vi.fn()}
+        onReset={vi.fn()}
+        onRetry={vi.fn()}
+        onDelete={vi.fn()}
+        onOpenWorkspace={vi.fn()}
+        onCompleteManualPr={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText('Supervisor Feedback')).toBeTruthy();
+    expect(screen.getByText(/rejected 2\/3/)).toBeTruthy();
+    expect(screen.getByText('Missing implementation steps for the auth module.')).toBeTruthy();
+  });
 });

--- a/client/src/useFactory.js
+++ b/client/src/useFactory.js
@@ -160,6 +160,20 @@ export default function useFactory() {
         case 'MAX_REVIEW_BLOCKER_EXTENDED':
           addNotification(`Task ${msg.payload.taskId} allowed one more review (${msg.payload.maxReviewCycles} max)`, 'info');
           break;
+        case 'SUPERVISOR_DECISION': {
+          const { taskId: sTaskId, stage, decision, feedback } = msg.payload || {};
+          const label = stage === 'plan' ? 'plan' : 'review';
+          if (decision === 'APPROVE') {
+            addNotification(`Supervisor auto-approved ${label} for ${sTaskId}`, 'success');
+          } else if (decision === 'REJECT') {
+            addNotification(`Supervisor rejected ${label} for ${sTaskId}: ${feedback || ''}`, 'warning');
+          } else if (decision === 'RETRY') {
+            addNotification(`Supervisor retrying ${label} for ${sTaskId}`, 'info');
+          } else if (decision === 'ESCALATE') {
+            addNotification(`Supervisor escalated ${sTaskId} — human input needed`, 'error');
+          }
+          break;
+        }
         case 'SETTINGS_ERROR':
           addNotification((msg.payload?.errors || []).join(', ') || 'Settings update failed', 'error');
           break;

--- a/client/src/useFactory.js
+++ b/client/src/useFactory.js
@@ -161,12 +161,12 @@ export default function useFactory() {
           addNotification(`Task ${msg.payload.taskId} allowed one more review (${msg.payload.maxReviewCycles} max)`, 'info');
           break;
         case 'SUPERVISOR_DECISION': {
-          const { taskId: sTaskId, stage, decision, feedback } = msg.payload || {};
+          const { taskId: sTaskId, stage, decision } = msg.payload || {};
           const label = stage === 'plan' ? 'plan' : 'review';
           if (decision === 'APPROVE') {
             addNotification(`Supervisor auto-approved ${label} for ${sTaskId}`, 'success');
           } else if (decision === 'REJECT') {
-            addNotification(`Supervisor rejected ${label} for ${sTaskId}: ${feedback || ''}`, 'warning');
+            addNotification(`Supervisor rejected ${label} for ${sTaskId}`, 'warning');
           } else if (decision === 'RETRY') {
             addNotification(`Supervisor retrying ${label} for ${sTaskId}`, 'info');
           } else if (decision === 'ESCALATE') {

--- a/client/src/useFactory.js
+++ b/client/src/useFactory.js
@@ -170,7 +170,7 @@ export default function useFactory() {
           } else if (decision === 'RETRY') {
             addNotification(`Supervisor retrying ${label} for ${sTaskId}`, 'info');
           } else if (decision === 'ESCALATE') {
-            addNotification(`Supervisor escalated ${sTaskId} — human input needed`, 'error');
+            addNotification(`Supervisor escalated ${label} for ${sTaskId} — human input needed`, 'error');
           }
           break;
         }

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -4,6 +4,7 @@ import { getRuntimePaths } from './paths.js';
 const runtimePaths = getRuntimePaths();
 
 export const DEFAULT_WORKSPACES_DIR = runtimePaths.workspacesDir;
+export const VALID_AUTOPILOT_MODES = ['manual', 'autopilot', 'hybrid'];
 
 let envVars = {};
 try {
@@ -203,8 +204,7 @@ function normalizeSettingsShape(data) {
     data.maxReviewCycles = defaults.maxReviewCycles;
   }
 
-  const validModes = ['manual', 'autopilot', 'hybrid'];
-  if (!validModes.includes(data.autopilotMode)) {
+  if (!VALID_AUTOPILOT_MODES.includes(data.autopilotMode)) {
     data.autopilotMode = defaults.autopilotMode;
   }
 
@@ -281,8 +281,7 @@ export function validateSettings(settings) {
     errors.push('maxReviewCycles must be a number between 1 and 20');
   }
 
-  const validAutopilotModes = ['manual', 'autopilot', 'hybrid'];
-  if (settings.autopilotMode !== undefined && !validAutopilotModes.includes(settings.autopilotMode)) {
+  if (settings.autopilotMode !== undefined && !VALID_AUTOPILOT_MODES.includes(settings.autopilotMode)) {
     errors.push('autopilotMode must be one of: manual, autopilot, hybrid');
   }
 

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -164,6 +164,7 @@ export function getDefaults() {
       reviewers:    { max: 4, cli: 'claude', model: '' },
     },
     maxReviewCycles: 3,
+    autopilotMode: 'manual',
     prompts: { ...DEFAULT_PROMPTS },
   };
 }
@@ -200,6 +201,11 @@ function normalizeSettingsShape(data) {
 
   if (typeof data.maxReviewCycles !== 'number' || data.maxReviewCycles < 1) {
     data.maxReviewCycles = defaults.maxReviewCycles;
+  }
+
+  const validModes = ['manual', 'autopilot', 'hybrid'];
+  if (!validModes.includes(data.autopilotMode)) {
+    data.autopilotMode = defaults.autopilotMode;
   }
 
   data.prompts = {
@@ -273,6 +279,11 @@ export function validateSettings(settings) {
 
   if (typeof settings.maxReviewCycles !== 'number' || settings.maxReviewCycles < 1 || settings.maxReviewCycles > 20) {
     errors.push('maxReviewCycles must be a number between 1 and 20');
+  }
+
+  const validAutopilotModes = ['manual', 'autopilot', 'hybrid'];
+  if (settings.autopilotMode !== undefined && !validAutopilotModes.includes(settings.autopilotMode)) {
+    errors.push('autopilotMode must be one of: manual, autopilot, hybrid');
   }
 
   if (!settings.prompts || typeof settings.prompts !== 'object') {

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -163,8 +163,10 @@ export function getDefaults() {
       planners:     { max: 4, cli: 'claude', model: '' },
       implementors: { max: 8, cli: getLegacyImplementorCli(), model: '' },
       reviewers:    { max: 4, cli: 'claude', model: '' },
+      supervisor:   { cli: 'claude', model: '' },
     },
     maxReviewCycles: 3,
+    maxPlanRejections: 3,
     autopilotMode: 'manual',
     prompts: { ...DEFAULT_PROMPTS },
   };
@@ -193,8 +195,10 @@ function normalizeSettingsShape(data) {
       data.agents = data.agents || {};
       data.agents[role] = defaults.agents[role];
     } else {
-      delete data.agents[role].count;
+      if (role !== 'supervisor') delete data.agents[role].count;
       if (typeof data.agents[role].model !== 'string') {
+        data.agents[role].model = '';
+      } else if (data.agents[role].model && !isValidModelForCli(data.agents[role].cli, data.agents[role].model)) {
         data.agents[role].model = '';
       }
     }
@@ -202,6 +206,10 @@ function normalizeSettingsShape(data) {
 
   if (typeof data.maxReviewCycles !== 'number' || data.maxReviewCycles < 1) {
     data.maxReviewCycles = defaults.maxReviewCycles;
+  }
+
+  if (typeof data.maxPlanRejections !== 'number' || data.maxPlanRejections < 1) {
+    data.maxPlanRejections = defaults.maxPlanRejections;
   }
 
   if (!VALID_AUTOPILOT_MODES.includes(data.autopilotMode)) {
@@ -277,8 +285,26 @@ export function validateSettings(settings) {
     }
   }
 
+  const supervisorCfg = settings.agents.supervisor;
+  if (supervisorCfg) {
+    if (!validClis.includes(supervisorCfg.cli)) {
+      errors.push(`supervisor.cli must be one of: ${validClis.join(', ')}`);
+    }
+    if (supervisorCfg.model !== undefined && typeof supervisorCfg.model !== 'string') {
+      errors.push('supervisor.model must be a string');
+    } else if (typeof supervisorCfg.model === 'string' && validClis.includes(supervisorCfg.cli) && !isValidModelForCli(supervisorCfg.cli, supervisorCfg.model)) {
+      errors.push(`supervisor.model '${supervisorCfg.model}' is not valid for the '${supervisorCfg.cli}' CLI`);
+    }
+  }
+
   if (typeof settings.maxReviewCycles !== 'number' || settings.maxReviewCycles < 1 || settings.maxReviewCycles > 20) {
     errors.push('maxReviewCycles must be a number between 1 and 20');
+  }
+
+  if (settings.maxPlanRejections !== undefined) {
+    if (typeof settings.maxPlanRejections !== 'number' || settings.maxPlanRejections < 1 || settings.maxPlanRejections > 10) {
+      errors.push('maxPlanRejections must be a number between 1 and 10');
+    }
   }
 
   if (settings.autopilotMode !== undefined && !VALID_AUTOPILOT_MODES.includes(settings.autopilotMode)) {

--- a/server/src/config.test.js
+++ b/server/src/config.test.js
@@ -280,6 +280,12 @@ describe('config settings lifecycle', () => {
       .not.toContain('autopilotMode must be one of: manual, autopilot, hybrid');
   });
 
+  test('exports VALID_AUTOPILOT_MODES with expected values', async () => {
+    harness = createRuntimeHarness();
+    const { VALID_AUTOPILOT_MODES } = await harness.importModule('./src/config.js');
+    expect(VALID_AUTOPILOT_MODES).toEqual(['manual', 'autopilot', 'hybrid']);
+  });
+
   test('returns early when agents are missing and validates repo types', async () => {
     harness = createRuntimeHarness();
     const { validateSettings } = await harness.importModule('./src/config.js');

--- a/server/src/config.test.js
+++ b/server/src/config.test.js
@@ -103,6 +103,44 @@ describe('config settings lifecycle', () => {
     expect(configModule.loadSettings().maxReviewCycles).toBe(10);
   });
 
+  test('getDefaults includes maxPlanRejections and normalizeSettingsShape corrects invalid values', async () => {
+    harness = createRuntimeHarness();
+    const configModule = await harness.importModule('./src/config.js');
+
+    const defaults = configModule.getDefaults();
+    expect(defaults.maxPlanRejections).toBe(3);
+
+    configModule.saveSettings({ ...defaults, maxPlanRejections: -1 });
+    expect(configModule.loadSettings().maxPlanRejections).toBe(3);
+
+    configModule.saveSettings({ ...defaults, maxPlanRejections: 'bad' });
+    expect(configModule.loadSettings().maxPlanRejections).toBe(3);
+
+    configModule.saveSettings({ ...defaults, maxPlanRejections: 7 });
+    expect(configModule.loadSettings().maxPlanRejections).toBe(7);
+  });
+
+  test('validateSettings rejects out-of-range maxPlanRejections', async () => {
+    harness = createRuntimeHarness();
+    const { validateSettings, getDefaults } = await harness.importModule('./src/config.js');
+    const base = {
+      ...getDefaults(),
+      repos: ['/repo'],
+      defaultRepoPath: '/repo',
+      workspaceRoot: '/tmp/ws',
+    };
+
+    expect(validateSettings({ ...base, maxPlanRejections: 0 }))
+      .toContain('maxPlanRejections must be a number between 1 and 10');
+    expect(validateSettings({ ...base, maxPlanRejections: 11 }))
+      .toContain('maxPlanRejections must be a number between 1 and 10');
+    expect(validateSettings({ ...base, maxPlanRejections: 5 }))
+      .not.toContain('maxPlanRejections must be a number between 1 and 10');
+    // undefined is allowed (backward compat)
+    expect(validateSettings({ ...base, maxPlanRejections: undefined }))
+      .not.toContain('maxPlanRejections must be a number between 1 and 10');
+  });
+
   test('validateSettings rejects out-of-range maxReviewCycles', async () => {
     harness = createRuntimeHarness();
     const { validateSettings, getDefaults } = await harness.importModule('./src/config.js');
@@ -150,6 +188,83 @@ describe('config settings lifecycle', () => {
     }
   });
 
+  test('defaults include supervisor with cli and model but no max', async () => {
+    harness = createRuntimeHarness();
+    const { getDefaults } = await harness.importModule('./src/config.js');
+    const defaults = getDefaults();
+    expect(defaults.agents.supervisor).toEqual({ cli: 'claude', model: '' });
+    expect(defaults.agents.supervisor.max).toBeUndefined();
+  });
+
+  test('normalizeSettingsShape backfills missing supervisor entry', async () => {
+    harness = createRuntimeHarness();
+    const configModule = await harness.importModule('./src/config.js');
+
+    configModule.saveSettings({
+      repos: ['/repo-a'],
+      defaultRepoPath: '/repo-a',
+      workspaceRoot: '/tmp/ws',
+      agents: {
+        planners: { max: 2, cli: 'claude' },
+        implementors: { max: 4, cli: 'claude' },
+        reviewers: { max: 2, cli: 'claude' },
+      },
+      prompts: { planning: 'p', implementation: 'i', review: 'r' },
+    });
+
+    const loaded = configModule.loadSettings();
+    expect(loaded.agents.supervisor).toEqual({ cli: 'claude', model: '' });
+  });
+
+  test('validateSettings validates supervisor cli and model', async () => {
+    harness = createRuntimeHarness();
+    const { validateSettings, getDefaults } = await harness.importModule('./src/config.js');
+    const base = {
+      ...getDefaults(),
+      repos: ['/repo'],
+      defaultRepoPath: '/repo',
+      workspaceRoot: '/tmp/ws',
+    };
+
+    // Valid supervisor config passes
+    expect(validateSettings({
+      ...base,
+      agents: { ...base.agents, supervisor: { cli: 'claude', model: 'claude-haiku-4-5' } },
+    })).toEqual([]);
+
+    // Invalid CLI rejected
+    expect(validateSettings({
+      ...base,
+      agents: { ...base.agents, supervisor: { cli: 'bad', model: '' } },
+    })).toContain('supervisor.cli must be one of: claude, codex');
+
+    // Model mismatch rejected
+    expect(validateSettings({
+      ...base,
+      agents: { ...base.agents, supervisor: { cli: 'codex', model: 'claude-haiku-4-5' } },
+    })).toContain("supervisor.model 'claude-haiku-4-5' is not valid for the 'codex' CLI");
+
+    // Non-string model rejected
+    expect(validateSettings({
+      ...base,
+      agents: { ...base.agents, supervisor: { cli: 'claude', model: 42 } },
+    })).toContain('supervisor.model must be a string');
+  });
+
+  test('validateSettings accepts settings without supervisor entry (backward compat)', async () => {
+    harness = createRuntimeHarness();
+    const { validateSettings, getDefaults } = await harness.importModule('./src/config.js');
+    const base = {
+      ...getDefaults(),
+      repos: ['/repo'],
+      defaultRepoPath: '/repo',
+      workspaceRoot: '/tmp/ws',
+    };
+    const { supervisor: _supervisor, ...agentsWithoutSupervisor } = base.agents;
+    const errors = validateSettings({ ...base, agents: agentsWithoutSupervisor });
+    expect(errors).toEqual([]);
+  });
+
   test('normalizeSettingsShape backfills missing model field', async () => {
     harness = createRuntimeHarness();
     const configModule = await harness.importModule('./src/config.js');
@@ -172,6 +287,30 @@ describe('config settings lifecycle', () => {
     expect(loaded.agents.planners.model).toBe('');
     expect(loaded.agents.implementors.model).toBe('');
     expect(loaded.agents.reviewers.model).toBe('');
+  });
+
+  test('normalizeSettingsShape resets invalid model values to empty string', async () => {
+    harness = createRuntimeHarness();
+    const configModule = await harness.importModule('./src/config.js');
+
+    configModule.saveSettings({
+      repos: ['/repo-a'],
+      defaultRepoPath: '/repo-a',
+      workspaceRoot: '/tmp/ws',
+      agents: {
+        planners: { max: 2, cli: 'claude', model: 'haiku' },
+        implementors: { max: 4, cli: 'codex', model: 'claude-opus-4-6' },
+        reviewers: { max: 2, cli: 'claude', model: 'nonexistent' },
+        supervisor: { cli: 'claude', model: 'bad-model' },
+      },
+      prompts: { planning: 'p', implementation: 'i', review: 'r' },
+    });
+
+    const loaded = configModule.loadSettings();
+    expect(loaded.agents.planners.model).toBe('');
+    expect(loaded.agents.implementors.model).toBe('');
+    expect(loaded.agents.reviewers.model).toBe('');
+    expect(loaded.agents.supervisor.model).toBe('');
   });
 
   test('validateSettings accepts valid model strings and rejects non-strings', async () => {

--- a/server/src/config.test.js
+++ b/server/src/config.test.js
@@ -239,6 +239,47 @@ describe('config settings lifecycle', () => {
     expect(validateSettings(valid)).toEqual([]);
   });
 
+  test('getDefaults includes autopilotMode and normalizeSettingsShape corrects invalid values', async () => {
+    harness = createRuntimeHarness();
+    const configModule = await harness.importModule('./src/config.js');
+
+    const defaults = configModule.getDefaults();
+    expect(defaults.autopilotMode).toBe('manual');
+
+    // Invalid string falls back to default
+    configModule.saveSettings({ ...defaults, autopilotMode: 'invalid' });
+    expect(configModule.loadSettings().autopilotMode).toBe('manual');
+
+    // Missing field falls back to default
+    configModule.saveSettings({ ...defaults, autopilotMode: undefined });
+    expect(configModule.loadSettings().autopilotMode).toBe('manual');
+
+    // Valid values are preserved
+    for (const mode of ['manual', 'autopilot', 'hybrid']) {
+      configModule.saveSettings({ ...defaults, autopilotMode: mode });
+      expect(configModule.loadSettings().autopilotMode).toBe(mode);
+    }
+  });
+
+  test('validateSettings rejects invalid autopilotMode', async () => {
+    harness = createRuntimeHarness();
+    const { validateSettings, getDefaults } = await harness.importModule('./src/config.js');
+    const base = {
+      ...getDefaults(),
+      repos: ['/repo'],
+      defaultRepoPath: '/repo',
+      workspaceRoot: '/tmp/ws',
+    };
+
+    expect(validateSettings({ ...base, autopilotMode: 'bad' }))
+      .toContain('autopilotMode must be one of: manual, autopilot, hybrid');
+    expect(validateSettings({ ...base, autopilotMode: 'autopilot' }))
+      .not.toContain('autopilotMode must be one of: manual, autopilot, hybrid');
+    // undefined is allowed (treated as manual)
+    expect(validateSettings({ ...base, autopilotMode: undefined }))
+      .not.toContain('autopilotMode must be one of: manual, autopilot, hybrid');
+  });
+
   test('returns early when agents are missing and validates repo types', async () => {
     harness = createRuntimeHarness();
     const { validateSettings } = await harness.importModule('./src/config.js');

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -765,6 +765,7 @@ bus.on('max-review-blocker:approved', (data) => broadcast('MAX_REVIEW_BLOCKER_AP
 bus.on('max-review-blocker:extended', (data) => broadcast('MAX_REVIEW_BLOCKER_EXTENDED', data));
 bus.on('repos:updated', (repos) => broadcast('REPOS_UPDATED', { repos }));
 bus.on('plan:partial', (data) => broadcast('PLAN_PARTIAL', data));
+bus.on('supervisor:decision', (data) => broadcast('SUPERVISOR_DECISION', data));
 bus.on('task:aborted', (data) => broadcast('TASK_ABORTED', data));
 bus.on('task:reset', (data) => broadcast('TASK_RESET', data));
 bus.on('agent:updated', (agentStatus) => {

--- a/server/src/orchestrator-supervisor.test.js
+++ b/server/src/orchestrator-supervisor.test.js
@@ -1,0 +1,329 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const emitMock = vi.fn();
+const onMock = vi.fn();
+const removeAgentMock = vi.fn();
+const appendSessionMock = vi.fn();
+const appendLogMock = vi.fn();
+const savePlanMock = vi.fn();
+const createSessionEntryMock = vi.fn((_agent, data) => data);
+const evaluatePlanMock = vi.fn();
+const evaluateReviewFailureMock = vi.fn();
+
+let taskState;
+let agentState;
+let settingsState;
+
+vi.mock('./config.js', () => ({
+  loadSettings: () => settingsState,
+  getWorkspacesDir: () => '/tmp/workspaces',
+}));
+
+vi.mock('./supervisor.js', () => ({
+  evaluatePlan: (...args) => evaluatePlanMock(...args),
+  evaluateReviewFailure: (...args) => evaluateReviewFailureMock(...args),
+}));
+
+vi.mock('./capabilities.js', () => ({
+  getGithubCapabilities: vi.fn(() => ({})),
+  isManualPullRequestRequired: vi.fn(() => false),
+}));
+
+vi.mock('./store.js', () => ({
+  default: {
+    getTask: (taskId) => taskState.get(taskId) || null,
+    updateTask: (taskId, update) => {
+      const current = taskState.get(taskId) || { id: taskId };
+      taskState.set(taskId, { ...current, ...update });
+    },
+    savePlan: (...args) => savePlanMock(...args),
+    appendSession: (...args) => appendSessionMock(...args),
+    appendLog: (...args) => appendLogMock(...args),
+  },
+}));
+
+vi.mock('./agents.js', () => ({
+  default: {
+    get: (agentId) => agentState.get(agentId) || null,
+    removeAgent: (...args) => removeAgentMock(...args),
+    getAvailableImplementor: vi.fn(() => null),
+  },
+}));
+
+vi.mock('./events.js', () => ({
+  default: {
+    emit: (...args) => emitMock(...args),
+    on: (...args) => onMock(...args),
+  },
+}));
+
+vi.mock('./sessionHistory.js', () => ({
+  createSessionEntry: (...args) => createSessionEntryMock(...args),
+}));
+
+vi.mock('simple-git', () => ({
+  simpleGit: vi.fn(),
+}));
+
+const flushPromises = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+function makePlanner(planText) {
+  return {
+    id: 'plan-1',
+    cli: 'claude',
+    currentTask: 'T-PLAN',
+    getBufferString: vi.fn(() => planText),
+    getStructuredBlock: vi.fn(() => planText),
+    kill: vi.fn(),
+  };
+}
+
+function makeReviewer(reviewText) {
+  return {
+    id: 'rev-1',
+    cli: 'claude',
+    currentTask: 'T-REVIEW',
+    getBufferString: vi.fn(() => reviewText),
+    getStructuredBlock: vi.fn(() => reviewText),
+    kill: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  taskState = new Map();
+  agentState = new Map();
+  settingsState = {
+    autopilotMode: 'manual',
+    maxReviewCycles: 3,
+    agents: {
+      planners: { cli: 'claude', model: '' },
+    },
+  };
+  emitMock.mockReset();
+  onMock.mockReset();
+  removeAgentMock.mockReset();
+  appendSessionMock.mockReset();
+  appendLogMock.mockReset();
+  savePlanMock.mockReset();
+  createSessionEntryMock.mockClear();
+  evaluatePlanMock.mockReset();
+  evaluateReviewFailureMock.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('orchestrator supervisor flows', () => {
+  test('auto-approves plans only in hybrid/autopilot modes', async () => {
+    const planText = `=== PLAN START ===
+SUMMARY: Ship autopilot.
+BRANCH: feature/t-plan-autopilot
+FILES_TO_MODIFY:
+- server/src/orchestrator.js (wire auto approval)
+STEPS:
+1. Evaluate plan with supervisor.
+TESTS_NEEDED:
+- npm run test:server
+RISKS:
+- none
+=== PLAN END ===`;
+
+    const planner = makePlanner(planText);
+    agentState.set('plan-1', planner);
+    taskState.set('T-PLAN', {
+      id: 'T-PLAN',
+      title: 'Plan task',
+      priority: 'medium',
+      status: 'planning',
+    });
+
+    evaluatePlanMock.mockResolvedValue({ decision: 'APPROVE', feedback: 'Looks good.' });
+
+    const { __test__ } = await import('./orchestrator.js');
+
+    settingsState.autopilotMode = 'manual';
+    __test__.onPlanComplete('plan-1', 'T-PLAN');
+    await flushPromises();
+    expect(evaluatePlanMock).not.toHaveBeenCalled();
+    expect(taskState.get('T-PLAN').status).toBe('awaiting_approval');
+
+    settingsState.autopilotMode = 'hybrid';
+    taskState.set('T-PLAN', {
+      id: 'T-PLAN',
+      title: 'Plan task',
+      priority: 'medium',
+      status: 'planning',
+    });
+    agentState.set('plan-1', makePlanner(planText));
+    __test__.onPlanComplete('plan-1', 'T-PLAN');
+    await flushPromises();
+
+    expect(evaluatePlanMock).toHaveBeenCalledOnce();
+    expect(emitMock).toHaveBeenCalledWith('supervisor:decision', {
+      taskId: 'T-PLAN',
+      stage: 'plan',
+      decision: 'APPROVE',
+      feedback: 'Looks good.',
+    });
+    expect(taskState.get('T-PLAN').status).toBe('queued');
+  });
+
+  test('does not auto-approve a plan after the task leaves awaiting_approval', async () => {
+    const planText = `=== PLAN START ===
+SUMMARY: Guard plan approval races.
+BRANCH: feature/t-plan-race
+FILES_TO_MODIFY:
+- server/src/orchestrator.js (add race guard)
+STEPS:
+1. Leave task untouched when a human already acted.
+TESTS_NEEDED:
+- npm run test:server
+RISKS:
+- none
+=== PLAN END ===`;
+
+    settingsState.autopilotMode = 'autopilot';
+    const planner = makePlanner(planText);
+    agentState.set('plan-1', planner);
+    taskState.set('T-PLAN', {
+      id: 'T-PLAN',
+      title: 'Plan race',
+      priority: 'medium',
+      status: 'planning',
+    });
+
+    let resolvePlan;
+    evaluatePlanMock.mockReturnValue(new Promise((resolve) => {
+      resolvePlan = resolve;
+    }));
+
+    const { __test__ } = await import('./orchestrator.js');
+    __test__.onPlanComplete('plan-1', 'T-PLAN');
+
+    taskState.set('T-PLAN', {
+      ...taskState.get('T-PLAN'),
+      status: 'queued',
+    });
+
+    resolvePlan({ decision: 'APPROVE', feedback: 'Late approval.' });
+    await flushPromises();
+
+    expect(emitMock).not.toHaveBeenCalledWith(
+      'supervisor:decision',
+      expect.objectContaining({ taskId: 'T-PLAN', stage: 'plan' })
+    );
+    expect(taskState.get('T-PLAN').status).toBe('queued');
+  });
+
+  test('routes review failures differently in manual and autopilot modes', async () => {
+    const reviewText = `=== REVIEW START ===
+VERDICT: FAIL
+CRITICAL_ISSUES:
+- fix null handling
+MINOR_ISSUES:
+- none
+SUMMARY: Needs one more pass.
+=== REVIEW END ===`;
+
+    const { __test__ } = await import('./orchestrator.js');
+
+    settingsState.autopilotMode = 'manual';
+    taskState.set('T-REVIEW', {
+      id: 'T-REVIEW',
+      title: 'Review task',
+      status: 'review',
+      reviewCycleCount: 0,
+      maxReviewCycles: 3,
+      workspacePath: '/tmp/workspace',
+    });
+    agentState.set('rev-1', makeReviewer(reviewText));
+
+    await __test__.onReviewComplete('rev-1', 'T-REVIEW');
+    expect(evaluateReviewFailureMock).not.toHaveBeenCalled();
+    expect(taskState.get('T-REVIEW')).toMatchObject({
+      status: 'queued',
+      reviewFeedback: 'fix null handling',
+      reviewCycleCount: 1,
+    });
+
+    settingsState.autopilotMode = 'autopilot';
+    evaluateReviewFailureMock.mockResolvedValue({
+      decision: 'ESCALATE',
+      enhancedFeedback: 'Needs human judgement.',
+    });
+    taskState.set('T-REVIEW', {
+      id: 'T-REVIEW',
+      title: 'Review task',
+      status: 'review',
+      reviewCycleCount: 0,
+      maxReviewCycles: 3,
+      workspacePath: '/tmp/workspace',
+    });
+    agentState.set('rev-1', makeReviewer(reviewText));
+
+    await __test__.onReviewComplete('rev-1', 'T-REVIEW');
+    await flushPromises();
+
+    expect(evaluateReviewFailureMock).toHaveBeenCalledOnce();
+    expect(emitMock).toHaveBeenCalledWith('supervisor:decision', {
+      taskId: 'T-REVIEW',
+      stage: 'review-failure',
+      decision: 'ESCALATE',
+      feedback: 'Needs human judgement.',
+    });
+    expect(taskState.get('T-REVIEW')).toMatchObject({
+      status: 'blocked',
+      reviewFeedback: 'fix null handling',
+      reviewCycleCount: 1,
+      blockedReason: 'Supervisor escalated: Needs human judgement.',
+    });
+  });
+
+  test('blocks when supervisor extension cap is exhausted', async () => {
+    const reviewText = `=== REVIEW START ===
+VERDICT: FAIL
+CRITICAL_ISSUES:
+- fix flaky retry loop
+MINOR_ISSUES:
+- none
+SUMMARY: Another retry would exceed the cap.
+=== REVIEW END ===`;
+
+    const { __test__, MAX_SUPERVISOR_EXTENSIONS } = await import('./orchestrator.js');
+
+    settingsState.autopilotMode = 'autopilot';
+    settingsState.maxReviewCycles = 3;
+    evaluateReviewFailureMock.mockResolvedValue({
+      decision: 'RETRY',
+      enhancedFeedback: 'Try once more.',
+    });
+    taskState.set('T-REVIEW', {
+      id: 'T-REVIEW',
+      title: 'Review cap',
+      status: 'review',
+      reviewCycleCount: settingsState.maxReviewCycles + MAX_SUPERVISOR_EXTENSIONS - 1,
+      maxReviewCycles: settingsState.maxReviewCycles + MAX_SUPERVISOR_EXTENSIONS,
+      workspacePath: '/tmp/workspace',
+    });
+    agentState.set('rev-1', makeReviewer(reviewText));
+
+    await __test__.onReviewComplete('rev-1', 'T-REVIEW');
+    await flushPromises();
+
+    expect(taskState.get('T-REVIEW')).toMatchObject({
+      status: 'blocked',
+      reviewFeedback: 'fix flaky retry loop',
+      reviewCycleCount: settingsState.maxReviewCycles + MAX_SUPERVISOR_EXTENSIONS,
+    });
+    expect(taskState.get('T-REVIEW').blockedReason)
+      .toContain(`Supervisor exhausted ${MAX_SUPERVISOR_EXTENSIONS} extension(s)`);
+    expect(emitMock).toHaveBeenCalledWith('task:blocked', {
+      taskId: 'T-REVIEW',
+      reason: 'Supervisor exhausted cycle extensions',
+    });
+  });
+});

--- a/server/src/orchestrator-supervisor.test.js
+++ b/server/src/orchestrator-supervisor.test.js
@@ -253,7 +253,7 @@ SUMMARY: Needs one more pass.
     settingsState.autopilotMode = 'autopilot';
     evaluateReviewFailureMock.mockResolvedValue({
       decision: 'ESCALATE',
-      enhancedFeedback: 'Needs human judgement.',
+      feedback: 'Needs human judgement.',
     });
     taskState.set('T-REVIEW', {
       id: 'T-REVIEW',
@@ -271,7 +271,7 @@ SUMMARY: Needs one more pass.
     expect(evaluateReviewFailureMock).toHaveBeenCalledOnce();
     expect(emitMock).toHaveBeenCalledWith('supervisor:decision', {
       taskId: 'T-REVIEW',
-      stage: 'review-failure',
+      stage: 'review',
       decision: 'ESCALATE',
       feedback: 'Needs human judgement.',
     });
@@ -299,7 +299,7 @@ SUMMARY: Another retry would exceed the cap.
     settingsState.maxReviewCycles = 3;
     evaluateReviewFailureMock.mockResolvedValue({
       decision: 'RETRY',
-      enhancedFeedback: 'Try once more.',
+      feedback: 'Try once more.',
     });
     taskState.set('T-REVIEW', {
       id: 'T-REVIEW',
@@ -343,7 +343,7 @@ SUMMARY: Needs a fix.
     settingsState.maxReviewCycles = 3;
     evaluateReviewFailureMock.mockResolvedValue({
       decision: 'RETRY',
-      enhancedFeedback: 'Fix the edge case in parser.',
+      feedback: 'Fix the edge case in parser.',
       logMessage: 'Supervisor evaluated review failure: RETRY',
     });
     taskState.set('T-REVIEW', {
@@ -383,7 +383,7 @@ SUMMARY: One more try.
     settingsState.maxReviewCycles = 3;
     evaluateReviewFailureMock.mockResolvedValue({
       decision: 'RETRY',
-      enhancedFeedback: 'Try fixing the flaky test.',
+      feedback: 'Try fixing the flaky test.',
       logMessage: 'Supervisor evaluated review failure: RETRY',
     });
     taskState.set('T-REVIEW', {
@@ -526,7 +526,7 @@ SUMMARY: Race guard test.
     // Simulate human changing task status during supervisor evaluation
     taskState.set('T-REVIEW', { ...taskState.get('T-REVIEW'), status: 'queued' });
 
-    resolveReview({ decision: 'RETRY', enhancedFeedback: 'Late retry.', logMessage: 'log' });
+    resolveReview({ decision: 'RETRY', feedback: 'Late retry.', logMessage: 'log' });
     await promise;
     await flushPromises();
 

--- a/server/src/orchestrator-supervisor.test.js
+++ b/server/src/orchestrator-supervisor.test.js
@@ -326,4 +326,211 @@ SUMMARY: Another retry would exceed the cap.
       reason: 'Supervisor exhausted cycle extensions',
     });
   });
+
+  test('T1: RETRY on cycles-remaining autopilot path queues with enhanced feedback', async () => {
+    const reviewText = `=== REVIEW START ===
+VERDICT: FAIL
+CRITICAL_ISSUES:
+- handle edge case
+MINOR_ISSUES:
+- none
+SUMMARY: Needs a fix.
+=== REVIEW END ===`;
+
+    const { __test__ } = await import('./orchestrator.js');
+
+    settingsState.autopilotMode = 'autopilot';
+    settingsState.maxReviewCycles = 3;
+    evaluateReviewFailureMock.mockResolvedValue({
+      decision: 'RETRY',
+      enhancedFeedback: 'Fix the edge case in parser.',
+      logMessage: 'Supervisor evaluated review failure: RETRY',
+    });
+    taskState.set('T-REVIEW', {
+      id: 'T-REVIEW',
+      title: 'Review retry',
+      status: 'review',
+      reviewCycleCount: 0,
+      maxReviewCycles: 3,
+      workspacePath: '/tmp/workspace',
+    });
+    agentState.set('rev-1', makeReviewer(reviewText));
+
+    await __test__.onReviewComplete('rev-1', 'T-REVIEW');
+    await flushPromises();
+
+    expect(evaluateReviewFailureMock).toHaveBeenCalledOnce();
+    expect(taskState.get('T-REVIEW')).toMatchObject({
+      status: 'queued',
+      reviewFeedback: 'Fix the edge case in parser.',
+      reviewCycleCount: 1,
+    });
+  });
+
+  test('T2: successful cycle extension when RETRY at max cycles with extensions remaining', async () => {
+    const reviewText = `=== REVIEW START ===
+VERDICT: FAIL
+CRITICAL_ISSUES:
+- flaky test
+MINOR_ISSUES:
+- none
+SUMMARY: One more try.
+=== REVIEW END ===`;
+
+    const { __test__ } = await import('./orchestrator.js');
+
+    settingsState.autopilotMode = 'autopilot';
+    settingsState.maxReviewCycles = 3;
+    evaluateReviewFailureMock.mockResolvedValue({
+      decision: 'RETRY',
+      enhancedFeedback: 'Try fixing the flaky test.',
+      logMessage: 'Supervisor evaluated review failure: RETRY',
+    });
+    taskState.set('T-REVIEW', {
+      id: 'T-REVIEW',
+      title: 'Review extend',
+      status: 'review',
+      reviewCycleCount: 2,
+      maxReviewCycles: 3,
+      workspacePath: '/tmp/workspace',
+    });
+    agentState.set('rev-1', makeReviewer(reviewText));
+
+    await __test__.onReviewComplete('rev-1', 'T-REVIEW');
+    await flushPromises();
+
+    expect(taskState.get('T-REVIEW')).toMatchObject({
+      status: 'queued',
+      maxReviewCycles: 4,
+      reviewCycleCount: 3,
+    });
+  });
+
+  test('T3: catch fallback blocks at max cycles and retries when cycles remain', async () => {
+    const reviewText = `=== REVIEW START ===
+VERDICT: FAIL
+CRITICAL_ISSUES:
+- error
+MINOR_ISSUES:
+- none
+SUMMARY: Crash test.
+=== REVIEW END ===`;
+
+    const { __test__ } = await import('./orchestrator.js');
+    settingsState.autopilotMode = 'autopilot';
+    settingsState.maxReviewCycles = 3;
+
+    // Max cycles path: supervisor crash should block
+    evaluateReviewFailureMock.mockRejectedValue(new Error('CLI crashed'));
+    taskState.set('T-REVIEW', {
+      id: 'T-REVIEW',
+      title: 'Crash at max',
+      status: 'review',
+      reviewCycleCount: 2,
+      maxReviewCycles: 3,
+      workspacePath: '/tmp/workspace',
+    });
+    agentState.set('rev-1', makeReviewer(reviewText));
+
+    await __test__.onReviewComplete('rev-1', 'T-REVIEW');
+    await flushPromises();
+
+    expect(taskState.get('T-REVIEW').status).toBe('blocked');
+
+    // Cycles remaining path: supervisor crash should auto-retry
+    evaluateReviewFailureMock.mockRejectedValue(new Error('CLI crashed'));
+    taskState.set('T-REVIEW2', {
+      id: 'T-REVIEW2',
+      title: 'Crash with cycles',
+      status: 'review',
+      reviewCycleCount: 0,
+      maxReviewCycles: 3,
+      workspacePath: '/tmp/workspace',
+    });
+    agentState.set('rev-1', makeReviewer(reviewText));
+    agentState.get('rev-1').currentTask = 'T-REVIEW2';
+
+    await __test__.onReviewComplete('rev-1', 'T-REVIEW2');
+    await flushPromises();
+
+    expect(taskState.get('T-REVIEW2').status).toBe('queued');
+    expect(appendLogMock).toHaveBeenCalledWith('T-REVIEW2', expect.stringContaining('Supervisor crashed'));
+  });
+
+  test('T4: plan auto-approval catch leaves task in awaiting_approval and logs', async () => {
+    const planText = `=== PLAN START ===
+SUMMARY: Crash plan test.
+BRANCH: feature/t-plan-crash
+FILES_TO_MODIFY:
+- server/src/orchestrator.js
+STEPS:
+1. Test crash handling.
+TESTS_NEEDED:
+- npm run test:server
+RISKS:
+- none
+=== PLAN END ===`;
+
+    const { __test__ } = await import('./orchestrator.js');
+
+    settingsState.autopilotMode = 'autopilot';
+    evaluatePlanMock.mockRejectedValue(new Error('Supervisor process died'));
+
+    const planner = makePlanner(planText);
+    agentState.set('plan-1', planner);
+    taskState.set('T-PLAN', {
+      id: 'T-PLAN',
+      title: 'Plan crash',
+      priority: 'medium',
+      status: 'planning',
+    });
+
+    __test__.onPlanComplete('plan-1', 'T-PLAN');
+    await flushPromises();
+
+    expect(taskState.get('T-PLAN').status).toBe('awaiting_approval');
+    expect(appendLogMock).toHaveBeenCalledWith('T-PLAN', expect.stringContaining('Supervisor failed during plan auto-approval'));
+  });
+
+  test('review callback does not clobber task when status changed during supervisor evaluation', async () => {
+    const reviewText = `=== REVIEW START ===
+VERDICT: FAIL
+CRITICAL_ISSUES:
+- race condition check
+MINOR_ISSUES:
+- none
+SUMMARY: Race guard test.
+=== REVIEW END ===`;
+
+    const { __test__ } = await import('./orchestrator.js');
+    settingsState.autopilotMode = 'autopilot';
+    settingsState.maxReviewCycles = 3;
+
+    let resolveReview;
+    evaluateReviewFailureMock.mockReturnValue(new Promise((resolve) => {
+      resolveReview = resolve;
+    }));
+
+    taskState.set('T-REVIEW', {
+      id: 'T-REVIEW',
+      title: 'Race guard',
+      status: 'review',
+      reviewCycleCount: 0,
+      maxReviewCycles: 3,
+      workspacePath: '/tmp/workspace',
+    });
+    agentState.set('rev-1', makeReviewer(reviewText));
+
+    const promise = __test__.onReviewComplete('rev-1', 'T-REVIEW');
+
+    // Simulate human changing task status during supervisor evaluation
+    taskState.set('T-REVIEW', { ...taskState.get('T-REVIEW'), status: 'queued' });
+
+    resolveReview({ decision: 'RETRY', enhancedFeedback: 'Late retry.', logMessage: 'log' });
+    await promise;
+    await flushPromises();
+
+    // Task should remain in queued (human's action), not be clobbered
+    expect(taskState.get('T-REVIEW').status).toBe('queued');
+  });
 });

--- a/server/src/orchestrator-supervisor.test.js
+++ b/server/src/orchestrator-supervisor.test.js
@@ -492,6 +492,59 @@ RISKS:
     expect(appendLogMock).toHaveBeenCalledWith('T-PLAN', expect.stringContaining('Supervisor failed during plan auto-approval'));
   });
 
+  test('plan rejection escalates to human after maxPlanRejections', async () => {
+    const planText = `=== PLAN START ===
+SUMMARY: Rejection limit test.
+BRANCH: feature/t-plan-reject-limit
+FILES_TO_MODIFY:
+- server/src/orchestrator.js
+STEPS:
+1. Test rejection limit.
+TESTS_NEEDED:
+- npm run test:server
+RISKS:
+- none
+=== PLAN END ===`;
+
+    const { __test__ } = await import('./orchestrator.js');
+
+    settingsState.autopilotMode = 'autopilot';
+    settingsState.maxPlanRejections = 2;
+
+    // First rejection: should re-plan (go to backlog)
+    evaluatePlanMock.mockResolvedValue({ decision: 'REJECT', feedback: 'Missing steps.', logMessage: 'Rejected' });
+    const planner1 = makePlanner(planText);
+    agentState.set('plan-1', planner1);
+    taskState.set('T-PLAN', {
+      id: 'T-PLAN', title: 'Reject limit', priority: 'medium',
+      status: 'planning', planRejectionCount: 0,
+    });
+
+    __test__.onPlanComplete('plan-1', 'T-PLAN');
+    await flushPromises();
+
+    expect(taskState.get('T-PLAN').status).toBe('backlog');
+    expect(taskState.get('T-PLAN').planRejectionCount).toBe(1);
+
+    // Second rejection (at limit): should escalate, stay in awaiting_approval
+    const planner2 = makePlanner(planText);
+    agentState.set('plan-1', planner2);
+    taskState.set('T-PLAN', {
+      ...taskState.get('T-PLAN'),
+      status: 'planning', planRejectionCount: 1,
+    });
+
+    __test__.onPlanComplete('plan-1', 'T-PLAN');
+    await flushPromises();
+
+    expect(taskState.get('T-PLAN').status).toBe('awaiting_approval');
+    expect(taskState.get('T-PLAN').planRejectionCount).toBe(2);
+    expect(appendLogMock).toHaveBeenCalledWith('T-PLAN', expect.stringContaining('escalating to human review'));
+    expect(emitMock).toHaveBeenCalledWith('supervisor:decision', expect.objectContaining({
+      taskId: 'T-PLAN', stage: 'plan', decision: 'ESCALATE',
+    }));
+  });
+
   test('review callback does not clobber task when status changed during supervisor evaluation', async () => {
     const reviewText = `=== REVIEW START ===
 VERDICT: FAIL

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { simpleGit } from 'simple-git';
 import { loadSettings, getWorkspacesDir } from './config.js';
+import { evaluatePlan, evaluateReviewFailure } from './supervisor.js';
 import { getGithubCapabilities, isManualPullRequestRequired } from './capabilities.js';
 import store from './store.js';
 import agentManager from './agents.js';
@@ -26,6 +27,10 @@ const REVIEWER_TIMEOUT = 30 * 60 * 1000;
 const STUCK_TIMEOUT = 10 * 60 * 1000;
 function getMaxReviewCycles() {
   return loadSettings().maxReviewCycles || 3;
+}
+
+function getAutopilotMode() {
+  return loadSettings().autopilotMode || 'manual';
 }
 
 let pollTimer = null;
@@ -879,6 +884,28 @@ function onPlanComplete(agentId, taskId) {
 
   retireAgentSession(planner, { taskId, outcome: 'completed', transcript: planText });
   bus.emit('plan:ready', { taskId, plan: planText });
+
+  // Supervisor auto-approval for autopilot and hybrid modes
+  const mode = getAutopilotMode();
+  if (mode === 'autopilot' || mode === 'hybrid') {
+    const settings = loadSettings();
+    evaluatePlan(store.getTask(taskId), settings).then((result) => {
+      // Guard against race condition: user may have manually approved/rejected
+      const current = store.getTask(taskId);
+      if (!current || current.status !== 'awaiting_approval') return;
+
+      bus.emit('supervisor:decision', { taskId, stage: 'plan', decision: result.decision, feedback: result.feedback });
+
+      if (result.decision === 'APPROVE') {
+        approvePlan(taskId);
+      } else if (result.decision === 'REJECT') {
+        rejectPlan(taskId, result.feedback);
+      }
+      // ESCALATE: leave in awaiting_approval for human
+    }).catch(() => {
+      // On error, leave in awaiting_approval (fail-safe)
+    });
+  }
 }
 
 function approvePlan(taskId) {
@@ -1055,7 +1082,52 @@ async function onReviewComplete(agentId, taskId) {
     const nextReviewCycleCount = (task?.reviewCycleCount || 0) + 1;
     const maxReviewCycles = Math.max(1, task?.maxReviewCycles || getMaxReviewCycles());
 
+    const mode = getAutopilotMode();
+
     if (nextReviewCycleCount >= maxReviewCycles) {
+      if (mode === 'autopilot') {
+        // Let supervisor decide whether to extend cycles or escalate
+        const settings = loadSettings();
+        evaluateReviewFailure(store.getTask(taskId), reviewText, criticalIssues, settings).then((result) => {
+          const current = store.getTask(taskId);
+          if (!current) return;
+          bus.emit('supervisor:decision', { taskId, stage: 'review-max-cycles', decision: result.decision, feedback: result.enhancedFeedback });
+
+          if (result.decision === 'RETRY') {
+            // Extend max cycles by 1 and re-queue
+            store.updateTask(taskId, {
+              status: 'queued',
+              reviewFeedback: result.enhancedFeedback || criticalIssues,
+              reviewCycleCount: nextReviewCycleCount,
+              maxReviewCycles: maxReviewCycles + 1,
+              blockedReason: null,
+              assignedTo: null,
+            });
+            bus.emit('review:failed', { taskId, issues: criticalIssues });
+          } else {
+            store.updateTask(taskId, {
+              status: 'blocked',
+              reviewFeedback: criticalIssues,
+              reviewCycleCount: nextReviewCycleCount,
+              blockedReason: `Supervisor escalated after max review cycles (${maxReviewCycles}): ${result.enhancedFeedback || 'Human input required.'}`,
+              assignedTo: null,
+            });
+            bus.emit('task:blocked', { taskId, reason: 'Supervisor escalated at max review cycles' });
+          }
+        }).catch(() => {
+          // Fail-safe: block as normal
+          store.updateTask(taskId, {
+            status: 'blocked',
+            reviewFeedback: criticalIssues,
+            reviewCycleCount: nextReviewCycleCount,
+            blockedReason: `Reached maximum review cycles (${maxReviewCycles}). Human input required.`,
+            assignedTo: null,
+          });
+          bus.emit('task:blocked', { taskId, reason: 'Reached maximum review cycles' });
+        });
+        return;
+      }
+
       store.updateTask(taskId, {
         status: 'blocked',
         reviewFeedback: criticalIssues,
@@ -1067,6 +1139,49 @@ async function onReviewComplete(agentId, taskId) {
       return;
     }
 
+    // Review failed but cycles remain
+    if (mode === 'autopilot') {
+      // Let supervisor provide enhanced feedback for retry
+      const settings = loadSettings();
+      evaluateReviewFailure(store.getTask(taskId), reviewText, criticalIssues, settings).then((result) => {
+        const current = store.getTask(taskId);
+        if (!current) return;
+        bus.emit('supervisor:decision', { taskId, stage: 'review-failure', decision: result.decision, feedback: result.enhancedFeedback });
+
+        if (result.decision === 'RETRY') {
+          store.updateTask(taskId, {
+            status: 'queued',
+            reviewFeedback: result.enhancedFeedback || criticalIssues,
+            reviewCycleCount: nextReviewCycleCount,
+            blockedReason: null,
+            assignedTo: null,
+          });
+          bus.emit('review:failed', { taskId, issues: criticalIssues });
+        } else {
+          store.updateTask(taskId, {
+            status: 'blocked',
+            reviewFeedback: criticalIssues,
+            reviewCycleCount: nextReviewCycleCount,
+            blockedReason: `Supervisor escalated: ${result.enhancedFeedback || 'Human input required.'}`,
+            assignedTo: null,
+          });
+          bus.emit('task:blocked', { taskId, reason: 'Supervisor escalated review failure' });
+        }
+      }).catch(() => {
+        // Fail-safe: auto-retry with raw issues
+        store.updateTask(taskId, {
+          status: 'queued',
+          reviewFeedback: criticalIssues,
+          reviewCycleCount: nextReviewCycleCount,
+          blockedReason: null,
+          assignedTo: null,
+        });
+        bus.emit('review:failed', { taskId, issues: criticalIssues });
+      });
+      return;
+    }
+
+    // Manual and hybrid: auto-retry with raw critical issues
     store.updateTask(taskId, {
       status: 'queued',
       reviewFeedback: criticalIssues,

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -25,6 +25,7 @@ const PLANNER_TIMEOUT = 5 * 60 * 1000;
 const IMPLEMENTOR_TIMEOUT = 60 * 60 * 1000;
 const REVIEWER_TIMEOUT = 30 * 60 * 1000;
 const STUCK_TIMEOUT = 10 * 60 * 1000;
+export const MAX_SUPERVISOR_EXTENSIONS = 2;
 function getMaxReviewCycles() {
   return loadSettings().maxReviewCycles || 3;
 }
@@ -1094,7 +1095,21 @@ async function onReviewComplete(agentId, taskId) {
           bus.emit('supervisor:decision', { taskId, stage: 'review-max-cycles', decision: result.decision, feedback: result.enhancedFeedback });
 
           if (result.decision === 'RETRY') {
-            // Extend max cycles by 1 and re-queue
+            // Extend max cycles by 1, but enforce a hard cap to prevent infinite loops
+            const configuredMax = getMaxReviewCycles();
+            const extensionsSoFar = maxReviewCycles - configuredMax;
+            if (extensionsSoFar >= MAX_SUPERVISOR_EXTENSIONS) {
+              // Hard cap reached — block instead of extending further
+              store.updateTask(taskId, {
+                status: 'blocked',
+                reviewFeedback: criticalIssues,
+                reviewCycleCount: nextReviewCycleCount,
+                blockedReason: `Supervisor exhausted ${MAX_SUPERVISOR_EXTENSIONS} extension(s) beyond max review cycles (${configuredMax}). Human input required.`,
+                assignedTo: null,
+              });
+              bus.emit('task:blocked', { taskId, reason: 'Supervisor exhausted cycle extensions' });
+              return;
+            }
             store.updateTask(taskId, {
               status: 'queued',
               reviewFeedback: result.enhancedFeedback || criticalIssues,

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -1068,9 +1068,9 @@ SUMMARY: Review skipped because reviewer max is set to 0.
 
 async function handleSupervisorReviewDecision(taskId, reviewText, criticalIssues, nextReviewCycleCount, maxReviewCycles, settings, { allowExtension, snapshotConfiguredMax, mode }) {
   try {
-    const result = await evaluateReviewFailure(store.getTask(taskId), reviewText, criticalIssues, settings);
     const current = store.getTask(taskId);
     if (!current || current.status !== 'evaluating') return;
+    const result = await evaluateReviewFailure(current, reviewText, criticalIssues, settings);
     if (result.logMessage) store.appendLog(taskId, result.logMessage);
     bus.emit('supervisor:decision', { taskId, stage: 'review', decision: result.decision, feedback: result.feedback });
 

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -34,6 +34,10 @@ function getAutopilotMode() {
   return loadSettings().autopilotMode || 'manual';
 }
 
+function logSupervisorFailure(message, taskId, mode, error) {
+  console.error(message, { taskId, mode, error });
+}
+
 let pollTimer = null;
 let signalTimer = null;
 
@@ -903,7 +907,8 @@ function onPlanComplete(agentId, taskId) {
         rejectPlan(taskId, result.feedback);
       }
       // ESCALATE: leave in awaiting_approval for human
-    }).catch(() => {
+    }).catch((error) => {
+      logSupervisorFailure('Supervisor evaluation failed during plan auto-approval', taskId, mode, error);
       // On error, leave in awaiting_approval (fail-safe)
     });
   }
@@ -1129,7 +1134,8 @@ async function onReviewComplete(agentId, taskId) {
             });
             bus.emit('task:blocked', { taskId, reason: 'Supervisor escalated at max review cycles' });
           }
-        }).catch(() => {
+        }).catch((error) => {
+          logSupervisorFailure('Supervisor evaluation failed after max review cycles', taskId, mode, error);
           // Fail-safe: block as normal
           store.updateTask(taskId, {
             status: 'blocked',
@@ -1182,7 +1188,8 @@ async function onReviewComplete(agentId, taskId) {
           });
           bus.emit('task:blocked', { taskId, reason: 'Supervisor escalated review failure' });
         }
-      }).catch(() => {
+      }).catch((error) => {
+        logSupervisorFailure('Supervisor evaluation failed during review retry routing', taskId, mode, error);
         // Fail-safe: auto-retry with raw issues
         store.updateTask(taskId, {
           status: 'queued',
@@ -1698,3 +1705,7 @@ const orchestrator = {
 };
 
 export default orchestrator;
+export const __test__ = {
+  onPlanComplete,
+  onReviewComplete,
+};

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -30,12 +30,8 @@ function getMaxReviewCycles() {
   return loadSettings().maxReviewCycles || 3;
 }
 
-function getAutopilotMode() {
-  return loadSettings().autopilotMode || 'manual';
-}
-
 function logSupervisorFailure(message, taskId, mode, error) {
-  console.error(message, { taskId, mode, error });
+  console.error(message, { taskId, mode }, error);
 }
 
 let pollTimer = null;
@@ -891,14 +887,15 @@ function onPlanComplete(agentId, taskId) {
   bus.emit('plan:ready', { taskId, plan: planText });
 
   // Supervisor auto-approval for autopilot and hybrid modes
-  const mode = getAutopilotMode();
+  const settings = loadSettings();
+  const mode = settings.autopilotMode || 'manual';
   if (mode === 'autopilot' || mode === 'hybrid') {
-    const settings = loadSettings();
     evaluatePlan(store.getTask(taskId), settings).then((result) => {
       // Guard against race condition: user may have manually approved/rejected
       const current = store.getTask(taskId);
       if (!current || current.status !== 'awaiting_approval') return;
 
+      if (result.logMessage) store.appendLog(taskId, result.logMessage);
       bus.emit('supervisor:decision', { taskId, stage: 'plan', decision: result.decision, feedback: result.feedback });
 
       if (result.decision === 'APPROVE') {
@@ -909,6 +906,7 @@ function onPlanComplete(agentId, taskId) {
       // ESCALATE: leave in awaiting_approval for human
     }).catch((error) => {
       logSupervisorFailure('Supervisor evaluation failed during plan auto-approval', taskId, mode, error);
+      store.appendLog(taskId, 'Supervisor failed during plan auto-approval. Task remains in awaiting_approval for human review.');
       // On error, leave in awaiting_approval (fail-safe)
     });
   }
@@ -1058,6 +1056,88 @@ SUMMARY: Review skipped because reviewer max is set to 0.
   bus.emit('agent:updated', reviewer.getStatus());
 }
 
+async function handleSupervisorReviewDecision(taskId, reviewText, criticalIssues, nextReviewCycleCount, maxReviewCycles, settings, { allowExtension, snapshotConfiguredMax, mode }) {
+  const stage = allowExtension ? 'review-max-cycles' : 'review-failure';
+  try {
+    const result = await evaluateReviewFailure(store.getTask(taskId), reviewText, criticalIssues, settings);
+    const current = store.getTask(taskId);
+    if (!current || current.status !== 'review') return;
+    if (result.logMessage) store.appendLog(taskId, result.logMessage);
+    bus.emit('supervisor:decision', { taskId, stage, decision: result.decision, feedback: result.enhancedFeedback });
+
+    if (result.decision === 'RETRY') {
+      if (allowExtension) {
+        const extensionsSoFar = maxReviewCycles - snapshotConfiguredMax;
+        if (extensionsSoFar >= MAX_SUPERVISOR_EXTENSIONS) {
+          store.updateTask(taskId, {
+            status: 'blocked',
+            reviewFeedback: criticalIssues,
+            reviewCycleCount: nextReviewCycleCount,
+            blockedReason: `Supervisor exhausted ${MAX_SUPERVISOR_EXTENSIONS} extension(s) beyond max review cycles (${snapshotConfiguredMax}). Human input required.`,
+            assignedTo: null,
+          });
+          bus.emit('task:blocked', { taskId, reason: 'Supervisor exhausted cycle extensions' });
+          return;
+        }
+        store.updateTask(taskId, {
+          status: 'queued',
+          reviewFeedback: result.enhancedFeedback || criticalIssues,
+          reviewCycleCount: nextReviewCycleCount,
+          maxReviewCycles: maxReviewCycles + 1,
+          blockedReason: null,
+          assignedTo: null,
+        });
+      } else {
+        store.updateTask(taskId, {
+          status: 'queued',
+          reviewFeedback: result.enhancedFeedback || criticalIssues,
+          reviewCycleCount: nextReviewCycleCount,
+          blockedReason: null,
+          assignedTo: null,
+        });
+      }
+      bus.emit('review:failed', { taskId, issues: criticalIssues });
+    } else {
+      // ESCALATE
+      const reason = allowExtension
+        ? `Supervisor escalated after max review cycles (${maxReviewCycles}): ${result.enhancedFeedback || 'Human input required.'}`
+        : `Supervisor escalated: ${result.enhancedFeedback || 'Human input required.'}`;
+      store.updateTask(taskId, {
+        status: 'blocked',
+        reviewFeedback: criticalIssues,
+        reviewCycleCount: nextReviewCycleCount,
+        blockedReason: reason,
+        assignedTo: null,
+      });
+      bus.emit('task:blocked', { taskId, reason: 'Supervisor escalated review failure' });
+    }
+  } catch (error) {
+    logSupervisorFailure('Supervisor evaluation failed during review', taskId, mode, error);
+    if (allowExtension) {
+      // Fail-safe: block as normal
+      store.updateTask(taskId, {
+        status: 'blocked',
+        reviewFeedback: criticalIssues,
+        reviewCycleCount: nextReviewCycleCount,
+        blockedReason: `Reached maximum review cycles (${maxReviewCycles}). Human input required.`,
+        assignedTo: null,
+      });
+      bus.emit('task:blocked', { taskId, reason: 'Reached maximum review cycles' });
+    } else {
+      // Fail-safe: auto-retry with raw issues, but log that supervisor failed
+      store.appendLog(taskId, `Supervisor crashed during review routing. Falling back to auto-retry. Error: ${error.message}`);
+      store.updateTask(taskId, {
+        status: 'queued',
+        reviewFeedback: criticalIssues,
+        reviewCycleCount: nextReviewCycleCount,
+        blockedReason: null,
+        assignedTo: null,
+      });
+      bus.emit('review:failed', { taskId, issues: criticalIssues });
+    }
+  }
+}
+
 async function onReviewComplete(agentId, taskId) {
   const reviewer = agentManager.get(agentId);
   if (!reviewer) return;
@@ -1088,64 +1168,13 @@ async function onReviewComplete(agentId, taskId) {
     const nextReviewCycleCount = (task?.reviewCycleCount || 0) + 1;
     const maxReviewCycles = Math.max(1, task?.maxReviewCycles || getMaxReviewCycles());
 
-    const mode = getAutopilotMode();
+    const settings = loadSettings();
+    const mode = settings.autopilotMode || 'manual';
+    const snapshotConfiguredMax = settings.maxReviewCycles || 3;
 
     if (nextReviewCycleCount >= maxReviewCycles) {
       if (mode === 'autopilot') {
-        // Let supervisor decide whether to extend cycles or escalate
-        const settings = loadSettings();
-        evaluateReviewFailure(store.getTask(taskId), reviewText, criticalIssues, settings).then((result) => {
-          const current = store.getTask(taskId);
-          if (!current) return;
-          bus.emit('supervisor:decision', { taskId, stage: 'review-max-cycles', decision: result.decision, feedback: result.enhancedFeedback });
-
-          if (result.decision === 'RETRY') {
-            // Extend max cycles by 1, but enforce a hard cap to prevent infinite loops
-            const configuredMax = getMaxReviewCycles();
-            const extensionsSoFar = maxReviewCycles - configuredMax;
-            if (extensionsSoFar >= MAX_SUPERVISOR_EXTENSIONS) {
-              // Hard cap reached — block instead of extending further
-              store.updateTask(taskId, {
-                status: 'blocked',
-                reviewFeedback: criticalIssues,
-                reviewCycleCount: nextReviewCycleCount,
-                blockedReason: `Supervisor exhausted ${MAX_SUPERVISOR_EXTENSIONS} extension(s) beyond max review cycles (${configuredMax}). Human input required.`,
-                assignedTo: null,
-              });
-              bus.emit('task:blocked', { taskId, reason: 'Supervisor exhausted cycle extensions' });
-              return;
-            }
-            store.updateTask(taskId, {
-              status: 'queued',
-              reviewFeedback: result.enhancedFeedback || criticalIssues,
-              reviewCycleCount: nextReviewCycleCount,
-              maxReviewCycles: maxReviewCycles + 1,
-              blockedReason: null,
-              assignedTo: null,
-            });
-            bus.emit('review:failed', { taskId, issues: criticalIssues });
-          } else {
-            store.updateTask(taskId, {
-              status: 'blocked',
-              reviewFeedback: criticalIssues,
-              reviewCycleCount: nextReviewCycleCount,
-              blockedReason: `Supervisor escalated after max review cycles (${maxReviewCycles}): ${result.enhancedFeedback || 'Human input required.'}`,
-              assignedTo: null,
-            });
-            bus.emit('task:blocked', { taskId, reason: 'Supervisor escalated at max review cycles' });
-          }
-        }).catch((error) => {
-          logSupervisorFailure('Supervisor evaluation failed after max review cycles', taskId, mode, error);
-          // Fail-safe: block as normal
-          store.updateTask(taskId, {
-            status: 'blocked',
-            reviewFeedback: criticalIssues,
-            reviewCycleCount: nextReviewCycleCount,
-            blockedReason: `Reached maximum review cycles (${maxReviewCycles}). Human input required.`,
-            assignedTo: null,
-          });
-          bus.emit('task:blocked', { taskId, reason: 'Reached maximum review cycles' });
-        });
+        await handleSupervisorReviewDecision(taskId, reviewText, criticalIssues, nextReviewCycleCount, maxReviewCycles, settings, { allowExtension: true, snapshotConfiguredMax, mode });
         return;
       }
 
@@ -1162,44 +1191,7 @@ async function onReviewComplete(agentId, taskId) {
 
     // Review failed but cycles remain
     if (mode === 'autopilot') {
-      // Let supervisor provide enhanced feedback for retry
-      const settings = loadSettings();
-      evaluateReviewFailure(store.getTask(taskId), reviewText, criticalIssues, settings).then((result) => {
-        const current = store.getTask(taskId);
-        if (!current) return;
-        bus.emit('supervisor:decision', { taskId, stage: 'review-failure', decision: result.decision, feedback: result.enhancedFeedback });
-
-        if (result.decision === 'RETRY') {
-          store.updateTask(taskId, {
-            status: 'queued',
-            reviewFeedback: result.enhancedFeedback || criticalIssues,
-            reviewCycleCount: nextReviewCycleCount,
-            blockedReason: null,
-            assignedTo: null,
-          });
-          bus.emit('review:failed', { taskId, issues: criticalIssues });
-        } else {
-          store.updateTask(taskId, {
-            status: 'blocked',
-            reviewFeedback: criticalIssues,
-            reviewCycleCount: nextReviewCycleCount,
-            blockedReason: `Supervisor escalated: ${result.enhancedFeedback || 'Human input required.'}`,
-            assignedTo: null,
-          });
-          bus.emit('task:blocked', { taskId, reason: 'Supervisor escalated review failure' });
-        }
-      }).catch((error) => {
-        logSupervisorFailure('Supervisor evaluation failed during review retry routing', taskId, mode, error);
-        // Fail-safe: auto-retry with raw issues
-        store.updateTask(taskId, {
-          status: 'queued',
-          reviewFeedback: criticalIssues,
-          reviewCycleCount: nextReviewCycleCount,
-          blockedReason: null,
-          assignedTo: null,
-        });
-        bus.emit('review:failed', { taskId, issues: criticalIssues });
-      });
+      await handleSupervisorReviewDecision(taskId, reviewText, criticalIssues, nextReviewCycleCount, maxReviewCycles, settings, { allowExtension: false, snapshotConfiguredMax, mode });
       return;
     }
 

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -892,7 +892,9 @@ function onPlanComplete(agentId, taskId) {
   const settings = loadSettings();
   const mode = settings.autopilotMode || 'manual';
   if (mode === 'autopilot' || mode === 'hybrid') {
-    autoApprovePlan(taskId, settings, mode);
+    autoApprovePlan(taskId, settings, mode).catch((error) => {
+      logSupervisorFailure('Unhandled error in autoApprovePlan', taskId, mode, error);
+    });
   }
 }
 

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -31,7 +31,9 @@ function getMaxReviewCycles() {
 }
 
 function logSupervisorFailure(message, taskId, mode, error) {
-  console.error(message, { taskId, mode }, error);
+  const errorDetail = error instanceof Error ? error.message : String(error);
+  const stack = error instanceof Error ? error.stack : undefined;
+  console.error(message, { taskId, mode, error: errorDetail, stack });
 }
 
 let pollTimer = null;
@@ -890,25 +892,31 @@ function onPlanComplete(agentId, taskId) {
   const settings = loadSettings();
   const mode = settings.autopilotMode || 'manual';
   if (mode === 'autopilot' || mode === 'hybrid') {
-    evaluatePlan(store.getTask(taskId), settings).then((result) => {
-      // Guard against race condition: user may have manually approved/rejected
-      const current = store.getTask(taskId);
-      if (!current || current.status !== 'awaiting_approval') return;
+    autoApprovePlan(taskId, settings, mode);
+  }
+}
 
-      if (result.logMessage) store.appendLog(taskId, result.logMessage);
-      bus.emit('supervisor:decision', { taskId, stage: 'plan', decision: result.decision, feedback: result.feedback });
+async function autoApprovePlan(taskId, settings, mode) {
+  try {
+    const result = await evaluatePlan(store.getTask(taskId), settings);
+    // Guard against race condition: user may have manually approved/rejected
+    const current = store.getTask(taskId);
+    if (!current || current.status !== 'awaiting_approval') return;
 
-      if (result.decision === 'APPROVE') {
-        approvePlan(taskId);
-      } else if (result.decision === 'REJECT') {
-        rejectPlan(taskId, result.feedback);
-      }
-      // ESCALATE: leave in awaiting_approval for human
-    }).catch((error) => {
-      logSupervisorFailure('Supervisor evaluation failed during plan auto-approval', taskId, mode, error);
-      store.appendLog(taskId, 'Supervisor failed during plan auto-approval. Task remains in awaiting_approval for human review.');
-      // On error, leave in awaiting_approval (fail-safe)
-    });
+    if (result.logMessage) store.appendLog(taskId, result.logMessage);
+    bus.emit('supervisor:decision', { taskId, stage: 'plan', decision: result.decision, feedback: result.feedback });
+
+    if (result.decision === 'APPROVE') {
+      approvePlan(taskId);
+    } else if (result.decision === 'REJECT') {
+      rejectPlan(taskId, result.feedback);
+    }
+    // ESCALATE: leave in awaiting_approval for human
+  } catch (error) {
+    const errorDetail = error instanceof Error ? error.message : String(error);
+    logSupervisorFailure('Supervisor evaluation failed during plan auto-approval', taskId, mode, error);
+    store.appendLog(taskId, `Supervisor failed during plan auto-approval: ${errorDetail}. Task remains in awaiting_approval for human review.`);
+    // On error, leave in awaiting_approval (fail-safe)
   }
 }
 
@@ -1057,13 +1065,12 @@ SUMMARY: Review skipped because reviewer max is set to 0.
 }
 
 async function handleSupervisorReviewDecision(taskId, reviewText, criticalIssues, nextReviewCycleCount, maxReviewCycles, settings, { allowExtension, snapshotConfiguredMax, mode }) {
-  const stage = allowExtension ? 'review-max-cycles' : 'review-failure';
   try {
     const result = await evaluateReviewFailure(store.getTask(taskId), reviewText, criticalIssues, settings);
     const current = store.getTask(taskId);
-    if (!current || current.status !== 'review') return;
+    if (!current || current.status !== 'evaluating') return;
     if (result.logMessage) store.appendLog(taskId, result.logMessage);
-    bus.emit('supervisor:decision', { taskId, stage, decision: result.decision, feedback: result.enhancedFeedback });
+    bus.emit('supervisor:decision', { taskId, stage: 'review', decision: result.decision, feedback: result.feedback });
 
     if (result.decision === 'RETRY') {
       if (allowExtension) {
@@ -1079,29 +1086,22 @@ async function handleSupervisorReviewDecision(taskId, reviewText, criticalIssues
           bus.emit('task:blocked', { taskId, reason: 'Supervisor exhausted cycle extensions' });
           return;
         }
-        store.updateTask(taskId, {
-          status: 'queued',
-          reviewFeedback: result.enhancedFeedback || criticalIssues,
-          reviewCycleCount: nextReviewCycleCount,
-          maxReviewCycles: maxReviewCycles + 1,
-          blockedReason: null,
-          assignedTo: null,
-        });
-      } else {
-        store.updateTask(taskId, {
-          status: 'queued',
-          reviewFeedback: result.enhancedFeedback || criticalIssues,
-          reviewCycleCount: nextReviewCycleCount,
-          blockedReason: null,
-          assignedTo: null,
-        });
       }
+      const update = {
+        status: 'queued',
+        reviewFeedback: result.feedback || criticalIssues,
+        reviewCycleCount: nextReviewCycleCount,
+        blockedReason: null,
+        assignedTo: null,
+      };
+      if (allowExtension) update.maxReviewCycles = maxReviewCycles + 1;
+      store.updateTask(taskId, update);
       bus.emit('review:failed', { taskId, issues: criticalIssues });
     } else {
       // ESCALATE
       const reason = allowExtension
-        ? `Supervisor escalated after max review cycles (${maxReviewCycles}): ${result.enhancedFeedback || 'Human input required.'}`
-        : `Supervisor escalated: ${result.enhancedFeedback || 'Human input required.'}`;
+        ? `Supervisor escalated after max review cycles (${maxReviewCycles}): ${result.feedback || 'Human input required.'}`
+        : `Supervisor escalated: ${result.feedback || 'Human input required.'}`;
       store.updateTask(taskId, {
         status: 'blocked',
         reviewFeedback: criticalIssues,
@@ -1125,7 +1125,8 @@ async function handleSupervisorReviewDecision(taskId, reviewText, criticalIssues
       bus.emit('task:blocked', { taskId, reason: 'Reached maximum review cycles' });
     } else {
       // Fail-safe: auto-retry with raw issues, but log that supervisor failed
-      store.appendLog(taskId, `Supervisor crashed during review routing. Falling back to auto-retry. Error: ${error.message}`);
+      const errorDetail = error instanceof Error ? error.message : String(error);
+      store.appendLog(taskId, `Supervisor crashed during review routing. Falling back to auto-retry. Error: ${errorDetail}`);
       store.updateTask(taskId, {
         status: 'queued',
         reviewFeedback: criticalIssues,
@@ -1174,6 +1175,8 @@ async function onReviewComplete(agentId, taskId) {
 
     if (nextReviewCycleCount >= maxReviewCycles) {
       if (mode === 'autopilot') {
+        // Prevent poll loop from re-spawning a reviewer during supervisor evaluation
+        store.updateTask(taskId, { status: 'evaluating', assignedTo: null });
         await handleSupervisorReviewDecision(taskId, reviewText, criticalIssues, nextReviewCycleCount, maxReviewCycles, settings, { allowExtension: true, snapshotConfiguredMax, mode });
         return;
       }
@@ -1191,6 +1194,8 @@ async function onReviewComplete(agentId, taskId) {
 
     // Review failed but cycles remain
     if (mode === 'autopilot') {
+      // Prevent poll loop from re-spawning a reviewer during supervisor evaluation
+      store.updateTask(taskId, { status: 'evaluating', assignedTo: null });
       await handleSupervisorReviewDecision(taskId, reviewText, criticalIssues, nextReviewCycleCount, maxReviewCycles, settings, { allowExtension: false, snapshotConfiguredMax, mode });
       return;
     }

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -911,7 +911,17 @@ async function autoApprovePlan(taskId, settings, mode) {
     if (result.decision === 'APPROVE') {
       approvePlan(taskId);
     } else if (result.decision === 'REJECT') {
-      rejectPlan(taskId, result.feedback);
+      const task = store.getTask(taskId);
+      const newCount = (task?.planRejectionCount || 0) + 1;
+      const maxRejections = settings.maxPlanRejections || 3;
+      if (newCount >= maxRejections) {
+        store.updateTask(taskId, { planRejectionCount: newCount, planFeedback: result.feedback });
+        store.appendLog(taskId, `Supervisor rejected plan ${newCount}/${maxRejections} times — escalating to human review.`);
+        bus.emit('supervisor:decision', { taskId, stage: 'plan', decision: 'ESCALATE', feedback: `Auto-escalated after ${newCount} rejections. Last: ${result.feedback}` });
+      } else {
+        store.updateTask(taskId, { planRejectionCount: newCount });
+        rejectPlan(taskId, result.feedback);
+      }
     }
     // ESCALATE: leave in awaiting_approval for human
   } catch (error) {
@@ -925,10 +935,11 @@ async function autoApprovePlan(taskId, settings, mode) {
 function approvePlan(taskId) {
   const task = store.getTask(taskId);
   if (!task || task.status !== 'awaiting_approval') return;
+  store.updateTask(taskId, { planRejectionCount: 0 });
   startImplementation(task);
 }
 
-function rejectPlan(taskId, feedback) {
+function rejectPlan(taskId, feedback, { resetRejectionCount = false } = {}) {
   const task = store.getTask(taskId);
   if (!task || task.status !== 'awaiting_approval') return;
 
@@ -937,6 +948,7 @@ function rejectPlan(taskId, feedback) {
     planFeedback: feedback,
     blockedReason: null,
     assignedTo: null,
+    ...(resetRejectionCount && { planRejectionCount: 0 }),
   });
 }
 
@@ -1631,7 +1643,7 @@ function pollLoop() {
 // --- Event Handlers ---
 
 bus.on('plan:approved', (taskId) => approvePlan(taskId));
-bus.on('plan:rejected', ({ taskId, feedback }) => rejectPlan(taskId, feedback));
+bus.on('plan:rejected', ({ taskId, feedback }) => rejectPlan(taskId, feedback, { resetRejectionCount: true }));
 
 bus.on('agent:unexpected-exit', ({ agentId, taskId }) => {
   const agent = agentManager.get(agentId);

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -1179,7 +1179,13 @@ async function onReviewComplete(agentId, taskId) {
       if (mode === 'autopilot') {
         // Prevent poll loop from re-spawning a reviewer during supervisor evaluation
         store.updateTask(taskId, { status: 'evaluating', assignedTo: null });
-        await handleSupervisorReviewDecision(taskId, reviewText, criticalIssues, nextReviewCycleCount, maxReviewCycles, settings, { allowExtension: true, snapshotConfiguredMax, mode });
+        try {
+          await handleSupervisorReviewDecision(taskId, reviewText, criticalIssues, nextReviewCycleCount, maxReviewCycles, settings, { allowExtension: true, snapshotConfiguredMax, mode });
+        } catch (error) {
+          logSupervisorFailure('Unhandled error in handleSupervisorReviewDecision', taskId, mode, error);
+          store.updateTask(taskId, { status: 'blocked', reviewFeedback: criticalIssues, reviewCycleCount: nextReviewCycleCount, blockedReason: 'Supervisor evaluation failed unexpectedly. Human input required.', assignedTo: null });
+          bus.emit('task:blocked', { taskId, reason: 'Supervisor evaluation failed' });
+        }
         return;
       }
 
@@ -1198,7 +1204,13 @@ async function onReviewComplete(agentId, taskId) {
     if (mode === 'autopilot') {
       // Prevent poll loop from re-spawning a reviewer during supervisor evaluation
       store.updateTask(taskId, { status: 'evaluating', assignedTo: null });
-      await handleSupervisorReviewDecision(taskId, reviewText, criticalIssues, nextReviewCycleCount, maxReviewCycles, settings, { allowExtension: false, snapshotConfiguredMax, mode });
+      try {
+        await handleSupervisorReviewDecision(taskId, reviewText, criticalIssues, nextReviewCycleCount, maxReviewCycles, settings, { allowExtension: false, snapshotConfiguredMax, mode });
+      } catch (error) {
+        logSupervisorFailure('Unhandled error in handleSupervisorReviewDecision', taskId, mode, error);
+        store.updateTask(taskId, { status: 'queued', reviewFeedback: criticalIssues, reviewCycleCount: nextReviewCycleCount, blockedReason: null, assignedTo: null });
+        bus.emit('review:failed', { taskId, issues: criticalIssues });
+      }
       return;
     }
 
@@ -1544,7 +1556,7 @@ function pollLoop() {
     if (agent.status === 'idle' && !agent.process && agent.currentTask) {
       const taskId = agent.currentTask;
       const task = store.getTask(taskId);
-      if (task && !['blocked', 'done', 'aborted', 'backlog', 'paused', 'workspace_setup'].includes(task.status)) {
+      if (task && !['blocked', 'done', 'aborted', 'backlog', 'paused', 'workspace_setup', 'evaluating'].includes(task.status)) {
         const isPlanner = agent.id.startsWith('plan-');
         const isImplementor = agent.id.startsWith('imp-');
         const isReviewer = agent.id.startsWith('rev-');

--- a/server/src/orchestrator.test.js
+++ b/server/src/orchestrator.test.js
@@ -7,6 +7,7 @@ import {
   extractImplementationResult,
   extractPlannerPlanText,
   extractReviewerReviewText,
+  MAX_SUPERVISOR_EXTENSIONS,
   sanitizeBranchName,
 } from './orchestrator.js';
 import { isImplementationPlaceholder } from './workflow.js';
@@ -555,6 +556,18 @@ RISKS:
     const cleaned = cleanTerminalArtifacts(dirty);
     expect(cleaned).toContain('BRANCH: feature/fix');
     expect(cleaned).not.toContain('❯');
+  });
+});
+
+describe('MAX_SUPERVISOR_EXTENSIONS', () => {
+  test('is exported as a positive integer', () => {
+    expect(typeof MAX_SUPERVISOR_EXTENSIONS).toBe('number');
+    expect(MAX_SUPERVISOR_EXTENSIONS).toBeGreaterThan(0);
+    expect(Number.isInteger(MAX_SUPERVISOR_EXTENSIONS)).toBe(true);
+  });
+
+  test('defaults to 2 to prevent unbounded cycle extensions', () => {
+    expect(MAX_SUPERVISOR_EXTENSIONS).toBe(2);
   });
 });
 

--- a/server/src/orchestrator.test.js
+++ b/server/src/orchestrator.test.js
@@ -557,3 +557,4 @@ RISKS:
     expect(cleaned).not.toContain('❯');
   });
 });
+

--- a/server/src/store.js
+++ b/server/src/store.js
@@ -243,6 +243,7 @@ class TaskStore {
       queued: 'queued',
       implementing: 'queued',
       review: 'review',
+      evaluating: 'review',
     };
     let changed = false;
     for (const task of this.tasks) {

--- a/server/src/store.js
+++ b/server/src/store.js
@@ -135,6 +135,7 @@ class TaskStore {
       assignedTo: null,
       reviewFeedback: null,
       planFeedback: null,
+      planRejectionCount: 0,
       blockedReason: null,
       workspacePath: null,
       reviewCycleCount: 0,

--- a/server/src/store.js
+++ b/server/src/store.js
@@ -12,7 +12,7 @@ const PLANS_DIR = runtimePaths.plansDir;
 function statusToStage(status) {
   if (['workspace_setup', 'planning', 'awaiting_approval'].includes(status)) return 'planning';
   if (['queued', 'implementing'].includes(status)) return 'implementation';
-  if (status === 'review') return 'review';
+  if (status === 'review' || status === 'evaluating') return 'review';
   if (status === 'done' || status === 'awaiting_manual_pr') return 'done';
   if (['backlog', 'aborted'].includes(status)) return 'backlog';
   return null;

--- a/server/src/supervisor-integration.test.js
+++ b/server/src/supervisor-integration.test.js
@@ -5,11 +5,6 @@ vi.mock('node:child_process', () => ({
   execFile: vi.fn(),
 }));
 
-// Mock store to prevent filesystem access
-vi.mock('./store.js', () => ({
-  default: { appendLog: vi.fn() },
-}));
-
 import { execFile } from 'node:child_process';
 import { evaluatePlan, evaluateReviewFailure } from './supervisor.js';
 
@@ -81,6 +76,16 @@ describe('supervisor integration — plan approval', () => {
     expect(result.feedback).toContain('Supervisor error');
   });
 
+  test('evaluatePlan includes stderr in error feedback when available', async () => {
+    execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+      cb(new Error('Exit code 1'), '', 'Error: unknown flag --bad');
+      return { on: vi.fn() };
+    });
+    const result = await evaluatePlan(mockTask, mockSettings);
+    expect(result.decision).toBe('ESCALATE');
+    expect(result.feedback).toContain('stderr: Error: unknown flag --bad');
+  });
+
   test('evaluatePlan falls back to ESCALATE on unparseable output', async () => {
     mockExecFileResponse('Random garbage with no markers');
     const result = await evaluatePlan(mockTask, mockSettings);
@@ -125,25 +130,63 @@ describe('supervisor integration — review failure', () => {
   });
 });
 
+describe('supervisor integration — CLI argument branching', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test('uses claude --print for claude CLI', async () => {
+    mockExecFileResponse(supervisorOutput('APPROVE', 'FEEDBACK', 'ok'));
+    await evaluatePlan(mockTask, { agents: { planners: { cli: 'claude', model: 'sonnet' } } });
+    expect(execFile).toHaveBeenCalledWith(
+      'claude',
+      expect.arrayContaining(['--print', '--model', 'sonnet']),
+      expect.any(Object),
+      expect.any(Function)
+    );
+  });
+
+  test('uses codex exec --sandbox read-only for codex CLI', async () => {
+    mockExecFileResponse(supervisorOutput('APPROVE', 'FEEDBACK', 'ok'));
+    await evaluatePlan(mockTask, { agents: { planners: { cli: 'codex', model: '' } } });
+    const args = execFile.mock.calls[0][1];
+    expect(execFile.mock.calls[0][0]).toBe('codex');
+    expect(args[0]).toBe('exec');
+    expect(args[1]).toBe('--sandbox');
+    expect(args[2]).toBe('read-only');
+    expect(args).not.toContain('--print');
+  });
+
+  test('passes -m flag for codex model', async () => {
+    mockExecFileResponse(supervisorOutput('APPROVE', 'FEEDBACK', 'ok'));
+    await evaluatePlan(mockTask, { agents: { planners: { cli: 'codex', model: 'gpt-4o' } } });
+    const args = execFile.mock.calls[0][1];
+    expect(args).toContain('-m');
+    expect(args).toContain('gpt-4o');
+  });
+});
+
 describe('supervisor integration — result structure contract', () => {
   beforeEach(() => vi.clearAllMocks());
 
-  test('evaluatePlan always returns { decision, feedback } strings', async () => {
+  test('evaluatePlan always returns { decision, feedback, logMessage } strings', async () => {
     mockExecFileResponse(supervisorOutput('APPROVE', 'FEEDBACK', ''));
     const result = await evaluatePlan(mockTask, mockSettings);
     expect(result).toHaveProperty('decision');
     expect(result).toHaveProperty('feedback');
+    expect(result).toHaveProperty('logMessage');
     expect(typeof result.decision).toBe('string');
     expect(typeof result.feedback).toBe('string');
+    expect(typeof result.logMessage).toBe('string');
   });
 
-  test('evaluateReviewFailure always returns { decision, enhancedFeedback } strings', async () => {
+  test('evaluateReviewFailure always returns { decision, enhancedFeedback, logMessage } strings', async () => {
     mockExecFileResponse(supervisorOutput('RETRY', 'ENHANCED_FEEDBACK', 'Fix it.'));
     const result = await evaluateReviewFailure(mockTask, 'text', 'issues', mockSettings);
     expect(result).toHaveProperty('decision');
     expect(result).toHaveProperty('enhancedFeedback');
+    expect(result).toHaveProperty('logMessage');
     expect(typeof result.decision).toBe('string');
     expect(typeof result.enhancedFeedback).toBe('string');
+    expect(typeof result.logMessage).toBe('string');
   });
 
   test('evaluatePlan result decision is always one of APPROVE/REJECT/ESCALATE', async () => {

--- a/server/src/supervisor-integration.test.js
+++ b/server/src/supervisor-integration.test.js
@@ -1,0 +1,161 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+
+// Mock child_process before importing supervisor so runSupervisorQuery uses the mock
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+}));
+
+// Mock store to prevent filesystem access
+vi.mock('./store.js', () => ({
+  default: { appendLog: vi.fn() },
+}));
+
+import { execFile } from 'node:child_process';
+import { evaluatePlan, evaluateReviewFailure } from './supervisor.js';
+
+function supervisorOutput(decision, feedbackLabel, feedbackText) {
+  return `=== SUPERVISOR DECISION START ===
+DECISION: ${decision}
+${feedbackLabel}: ${feedbackText}
+=== SUPERVISOR DECISION END ===`;
+}
+
+function mockExecFileResponse(stdout) {
+  execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+    cb(null, stdout);
+    return { on: vi.fn() };
+  });
+}
+
+function mockExecFileError(errorMessage) {
+  execFile.mockImplementation((_cmd, _args, _opts, cb) => {
+    cb(new Error(errorMessage), '');
+    return { on: vi.fn() };
+  });
+}
+
+const mockTask = { id: 'T-TEST01', title: 'Test task', description: 'A test', priority: 'medium', plan: 'Step 1: do stuff' };
+const mockSettings = { agents: { planners: { cli: 'claude', model: '' } } };
+
+describe('supervisor integration — plan approval', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test('evaluatePlan returns APPROVE for valid APPROVE response', async () => {
+    mockExecFileResponse(supervisorOutput('APPROVE', 'FEEDBACK', 'Plan looks solid.'));
+    const result = await evaluatePlan(mockTask, mockSettings);
+    expect(result.decision).toBe('APPROVE');
+    expect(result.feedback).toBe('Plan looks solid.');
+  });
+
+  test('evaluatePlan returns REJECT for valid REJECT response', async () => {
+    mockExecFileResponse(supervisorOutput('REJECT', 'FEEDBACK', 'Missing tests.'));
+    const result = await evaluatePlan(mockTask, mockSettings);
+    expect(result.decision).toBe('REJECT');
+    expect(result.feedback).toBe('Missing tests.');
+  });
+
+  test('evaluatePlan returns ESCALATE for valid ESCALATE response', async () => {
+    mockExecFileResponse(supervisorOutput('ESCALATE', 'FEEDBACK', 'Needs human review.'));
+    const result = await evaluatePlan(mockTask, mockSettings);
+    expect(result.decision).toBe('ESCALATE');
+  });
+
+  test('evaluatePlan falls back to ESCALATE for invalid decision (RETRY is not valid for plans)', async () => {
+    mockExecFileResponse(supervisorOutput('RETRY', 'FEEDBACK', 'Should not be allowed.'));
+    const result = await evaluatePlan(mockTask, mockSettings);
+    expect(result.decision).toBe('ESCALATE');
+    expect(result.feedback).toContain('Invalid supervisor decision: RETRY');
+  });
+
+  test('evaluatePlan falls back to ESCALATE for garbage decision', async () => {
+    mockExecFileResponse(supervisorOutput('MAYBE', 'FEEDBACK', 'Not sure.'));
+    const result = await evaluatePlan(mockTask, mockSettings);
+    expect(result.decision).toBe('ESCALATE');
+    expect(result.feedback).toContain('Invalid supervisor decision: MAYBE');
+  });
+
+  test('evaluatePlan falls back to ESCALATE on CLI error', async () => {
+    mockExecFileError('Command timed out');
+    const result = await evaluatePlan(mockTask, mockSettings);
+    expect(result.decision).toBe('ESCALATE');
+    expect(result.feedback).toContain('Supervisor error');
+  });
+
+  test('evaluatePlan falls back to ESCALATE on unparseable output', async () => {
+    mockExecFileResponse('Random garbage with no markers');
+    const result = await evaluatePlan(mockTask, mockSettings);
+    expect(result.decision).toBe('ESCALATE');
+  });
+});
+
+describe('supervisor integration — review failure', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test('evaluateReviewFailure returns RETRY with enhanced feedback', async () => {
+    mockExecFileResponse(supervisorOutput('RETRY', 'ENHANCED_FEEDBACK', 'Fix the null checks.'));
+    const result = await evaluateReviewFailure(mockTask, 'review output', 'null pointer', mockSettings);
+    expect(result.decision).toBe('RETRY');
+    expect(result.enhancedFeedback).toBe('Fix the null checks.');
+  });
+
+  test('evaluateReviewFailure returns ESCALATE for valid ESCALATE', async () => {
+    mockExecFileResponse(supervisorOutput('ESCALATE', 'ENHANCED_FEEDBACK', 'Needs human input.'));
+    const result = await evaluateReviewFailure(mockTask, 'review output', 'critical', mockSettings);
+    expect(result.decision).toBe('ESCALATE');
+  });
+
+  test('evaluateReviewFailure falls back to ESCALATE for invalid decision (APPROVE not valid for reviews)', async () => {
+    mockExecFileResponse(supervisorOutput('APPROVE', 'ENHANCED_FEEDBACK', 'Should not work.'));
+    const result = await evaluateReviewFailure(mockTask, 'review output', 'issues', mockSettings);
+    expect(result.decision).toBe('ESCALATE');
+    expect(result.enhancedFeedback).toContain('Invalid supervisor decision: APPROVE');
+  });
+
+  test('evaluateReviewFailure falls back to ESCALATE for REJECT (not valid for reviews)', async () => {
+    mockExecFileResponse(supervisorOutput('REJECT', 'ENHANCED_FEEDBACK', 'Should not work.'));
+    const result = await evaluateReviewFailure(mockTask, 'review output', 'issues', mockSettings);
+    expect(result.decision).toBe('ESCALATE');
+    expect(result.enhancedFeedback).toContain('Invalid supervisor decision: REJECT');
+  });
+
+  test('evaluateReviewFailure falls back to ESCALATE on CLI error', async () => {
+    mockExecFileError('Process killed');
+    const result = await evaluateReviewFailure(mockTask, 'review output', 'issues', mockSettings);
+    expect(result.decision).toBe('ESCALATE');
+  });
+});
+
+describe('supervisor integration — result structure contract', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  test('evaluatePlan always returns { decision, feedback } strings', async () => {
+    mockExecFileResponse(supervisorOutput('APPROVE', 'FEEDBACK', ''));
+    const result = await evaluatePlan(mockTask, mockSettings);
+    expect(result).toHaveProperty('decision');
+    expect(result).toHaveProperty('feedback');
+    expect(typeof result.decision).toBe('string');
+    expect(typeof result.feedback).toBe('string');
+  });
+
+  test('evaluateReviewFailure always returns { decision, enhancedFeedback } strings', async () => {
+    mockExecFileResponse(supervisorOutput('RETRY', 'ENHANCED_FEEDBACK', 'Fix it.'));
+    const result = await evaluateReviewFailure(mockTask, 'text', 'issues', mockSettings);
+    expect(result).toHaveProperty('decision');
+    expect(result).toHaveProperty('enhancedFeedback');
+    expect(typeof result.decision).toBe('string');
+    expect(typeof result.enhancedFeedback).toBe('string');
+  });
+
+  test('evaluatePlan result decision is always one of APPROVE/REJECT/ESCALATE', async () => {
+    // Even when CLI returns garbage, validation ensures valid decision
+    mockExecFileResponse(supervisorOutput('INVALID', 'FEEDBACK', 'bad'));
+    const result = await evaluatePlan(mockTask, mockSettings);
+    expect(['APPROVE', 'REJECT', 'ESCALATE']).toContain(result.decision);
+  });
+
+  test('evaluateReviewFailure result decision is always one of RETRY/ESCALATE', async () => {
+    mockExecFileResponse(supervisorOutput('INVALID', 'ENHANCED_FEEDBACK', 'bad'));
+    const result = await evaluateReviewFailure(mockTask, 'text', 'issues', mockSettings);
+    expect(['RETRY', 'ESCALATE']).toContain(result.decision);
+  });
+});

--- a/server/src/supervisor-integration.test.js
+++ b/server/src/supervisor-integration.test.js
@@ -100,7 +100,7 @@ describe('supervisor integration — review failure', () => {
     mockExecFileResponse(supervisorOutput('RETRY', 'ENHANCED_FEEDBACK', 'Fix the null checks.'));
     const result = await evaluateReviewFailure(mockTask, 'review output', 'null pointer', mockSettings);
     expect(result.decision).toBe('RETRY');
-    expect(result.enhancedFeedback).toBe('Fix the null checks.');
+    expect(result.feedback).toBe('Fix the null checks.');
   });
 
   test('evaluateReviewFailure returns ESCALATE for valid ESCALATE', async () => {
@@ -113,14 +113,14 @@ describe('supervisor integration — review failure', () => {
     mockExecFileResponse(supervisorOutput('APPROVE', 'ENHANCED_FEEDBACK', 'Should not work.'));
     const result = await evaluateReviewFailure(mockTask, 'review output', 'issues', mockSettings);
     expect(result.decision).toBe('ESCALATE');
-    expect(result.enhancedFeedback).toContain('Invalid supervisor decision: APPROVE');
+    expect(result.feedback).toContain('Invalid supervisor decision: APPROVE');
   });
 
   test('evaluateReviewFailure falls back to ESCALATE for REJECT (not valid for reviews)', async () => {
     mockExecFileResponse(supervisorOutput('REJECT', 'ENHANCED_FEEDBACK', 'Should not work.'));
     const result = await evaluateReviewFailure(mockTask, 'review output', 'issues', mockSettings);
     expect(result.decision).toBe('ESCALATE');
-    expect(result.enhancedFeedback).toContain('Invalid supervisor decision: REJECT');
+    expect(result.feedback).toContain('Invalid supervisor decision: REJECT');
   });
 
   test('evaluateReviewFailure falls back to ESCALATE on CLI error', async () => {
@@ -178,14 +178,14 @@ describe('supervisor integration — result structure contract', () => {
     expect(typeof result.logMessage).toBe('string');
   });
 
-  test('evaluateReviewFailure always returns { decision, enhancedFeedback, logMessage } strings', async () => {
+  test('evaluateReviewFailure always returns { decision, feedback, logMessage } strings', async () => {
     mockExecFileResponse(supervisorOutput('RETRY', 'ENHANCED_FEEDBACK', 'Fix it.'));
     const result = await evaluateReviewFailure(mockTask, 'text', 'issues', mockSettings);
     expect(result).toHaveProperty('decision');
-    expect(result).toHaveProperty('enhancedFeedback');
+    expect(result).toHaveProperty('feedback');
     expect(result).toHaveProperty('logMessage');
     expect(typeof result.decision).toBe('string');
-    expect(typeof result.enhancedFeedback).toBe('string');
+    expect(typeof result.feedback).toBe('string');
     expect(typeof result.logMessage).toBe('string');
   });
 

--- a/server/src/supervisor-integration.test.js
+++ b/server/src/supervisor-integration.test.js
@@ -17,15 +17,15 @@ ${feedbackLabel}: ${feedbackText}
 
 function mockExecFileResponse(stdout) {
   execFile.mockImplementation((_cmd, _args, _opts, cb) => {
-    cb(null, stdout);
-    return { on: vi.fn() };
+    cb(null, stdout, '');
+    return { on: vi.fn(), stdin: { write: vi.fn(), end: vi.fn() } };
   });
 }
 
 function mockExecFileError(errorMessage) {
   execFile.mockImplementation((_cmd, _args, _opts, cb) => {
-    cb(new Error(errorMessage), '');
-    return { on: vi.fn() };
+    cb(new Error(errorMessage), '', errorMessage);
+    return { on: vi.fn(), stdin: { write: vi.fn(), end: vi.fn() } };
   });
 }
 
@@ -79,7 +79,7 @@ describe('supervisor integration — plan approval', () => {
   test('evaluatePlan includes stderr in error feedback when available', async () => {
     execFile.mockImplementation((_cmd, _args, _opts, cb) => {
       cb(new Error('Exit code 1'), '', 'Error: unknown flag --bad');
-      return { on: vi.fn() };
+      return { on: vi.fn(), stdin: { write: vi.fn(), end: vi.fn() } };
     });
     const result = await evaluatePlan(mockTask, mockSettings);
     expect(result.decision).toBe('ESCALATE');

--- a/server/src/supervisor.js
+++ b/server/src/supervisor.js
@@ -11,7 +11,7 @@ const REVIEW_DECISIONS = new Set(['RETRY', 'ESCALATE']);
 
 function parseDecisionBlock(output) {
   const startIdx = output.indexOf(DECISION_START);
-  const endIdx = output.indexOf(DECISION_END);
+  const endIdx = output.indexOf(DECISION_END, startIdx + DECISION_START.length);
   if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) return null;
 
   const block = output.slice(startIdx + DECISION_START.length, endIdx).trim();
@@ -43,7 +43,7 @@ function runSupervisorQuery(cli, model, prompt) {
     args.push(prompt);
 
     const cliCmd = cli === 'codex' ? 'codex' : 'claude';
-    const child = execFile(cliCmd, args, {
+    execFile(cliCmd, args, {
       timeout: SUPERVISOR_TIMEOUT,
       encoding: 'utf-8',
       maxBuffer: 1024 * 1024,
@@ -56,11 +56,6 @@ function runSupervisorQuery(cli, model, prompt) {
         return resolve({ decision: 'ESCALATE', feedback: 'Supervisor returned unparseable output' });
       }
       resolve(parsed);
-    });
-
-    // Extra safety: kill on timeout (execFile timeout sends SIGTERM)
-    child.on('error', () => {
-      resolve({ decision: 'ESCALATE', feedback: 'Supervisor process error' });
     });
   });
 }

--- a/server/src/supervisor.js
+++ b/server/src/supervisor.js
@@ -1,5 +1,4 @@
 import { execFile } from 'node:child_process';
-import store from './store.js';
 
 const SUPERVISOR_TIMEOUT = 60_000;
 
@@ -8,6 +7,29 @@ const DECISION_END = '=== SUPERVISOR DECISION END ===';
 
 const PLAN_DECISIONS = new Set(['APPROVE', 'REJECT', 'ESCALATE']);
 const REVIEW_DECISIONS = new Set(['RETRY', 'ESCALATE']);
+
+const MAX_CONCURRENT_SUPERVISORS = 3;
+let activeSupervisors = 0;
+const supervisorQueue = [];
+
+function acquireSupervisorSlot() {
+  return new Promise((resolve) => {
+    if (activeSupervisors < MAX_CONCURRENT_SUPERVISORS) {
+      activeSupervisors++;
+      resolve();
+    } else {
+      supervisorQueue.push(resolve);
+    }
+  });
+}
+
+function releaseSupervisorSlot() {
+  activeSupervisors--;
+  if (supervisorQueue.length > 0) {
+    activeSupervisors++;
+    supervisorQueue.shift()();
+  }
+}
 
 function parseDecisionBlock(output) {
   const startIdx = output.indexOf(DECISION_START);
@@ -36,28 +58,43 @@ function validateDecision(result, validSet) {
   return result;
 }
 
-function runSupervisorQuery(cli, model, prompt) {
-  return new Promise((resolve) => {
-    const args = ['--print'];
-    if (model) args.push('--model', model);
-    args.push(prompt);
+async function runSupervisorQuery(cli, model, prompt) {
+  await acquireSupervisorSlot();
+  try {
+    return await new Promise((resolve) => {
+      let cliCmd, args;
+      if (cli === 'codex') {
+        cliCmd = 'codex';
+        args = ['exec', '--sandbox', 'read-only'];
+        if (model) args.push('-m', model);
+        args.push(prompt);
+      } else {
+        cliCmd = 'claude';
+        args = ['--print'];
+        if (model) args.push('--model', model);
+        args.push(prompt);
+      }
 
-    const cliCmd = cli === 'codex' ? 'codex' : 'claude';
-    execFile(cliCmd, args, {
-      timeout: SUPERVISOR_TIMEOUT,
-      encoding: 'utf-8',
-      maxBuffer: 1024 * 1024,
-    }, (err, stdout) => {
-      if (err) {
-        return resolve({ decision: 'ESCALATE', feedback: `Supervisor error: ${err.message}` });
-      }
-      const parsed = parseDecisionBlock(stdout);
-      if (!parsed) {
-        return resolve({ decision: 'ESCALATE', feedback: 'Supervisor returned unparseable output' });
-      }
-      resolve(parsed);
+      execFile(cliCmd, args, {
+        timeout: SUPERVISOR_TIMEOUT,
+        encoding: 'utf-8',
+        maxBuffer: 1024 * 1024,
+      }, (err, stdout, stderr) => {
+        if (err) {
+          const detail = stderr ? `${err.message}\nstderr: ${stderr}` : err.message;
+          return resolve({ decision: 'ESCALATE', feedback: `Supervisor error: ${detail}` });
+        }
+        const parsed = parseDecisionBlock(stdout);
+        if (!parsed) {
+          console.error('Supervisor returned unparseable output:', stdout?.slice(0, 500));
+          return resolve({ decision: 'ESCALATE', feedback: 'Supervisor returned unparseable output' });
+        }
+        resolve(parsed);
+      });
     });
-  });
+  } finally {
+    releaseSupervisorSlot();
+  }
 }
 
 export async function evaluatePlan(task, settings) {
@@ -93,8 +130,8 @@ ${DECISION_END}
   const raw = await runSupervisorQuery(cli, model, prompt);
   const result = validateDecision(raw, PLAN_DECISIONS)
     || { decision: 'ESCALATE', feedback: `Invalid supervisor decision: ${raw?.decision || 'none'}` };
-  store.appendLog(task.id, `Supervisor evaluated plan: ${result.decision}${result.feedback ? ' — ' + result.feedback : ''}`);
-  return result;
+  const logMessage = `Supervisor evaluated plan: ${result.decision}${result.feedback ? ' — ' + result.feedback : ''}`;
+  return { ...result, logMessage };
 }
 
 export async function evaluateReviewFailure(task, reviewText, criticalIssues, settings) {
@@ -128,9 +165,9 @@ ${DECISION_END}
   const raw = await runSupervisorQuery(cli, model, prompt);
   const result = validateDecision(raw, REVIEW_DECISIONS)
     || { decision: 'ESCALATE', feedback: `Invalid supervisor decision: ${raw?.decision || 'none'}` };
-  store.appendLog(task.id, `Supervisor evaluated review failure: ${result.decision}${result.feedback ? ' — ' + result.feedback : ''}`);
-  return { decision: result.decision, enhancedFeedback: result.feedback };
+  const logMessage = `Supervisor evaluated review failure: ${result.decision}${result.feedback ? ' — ' + result.feedback : ''}`;
+  return { decision: result.decision, enhancedFeedback: result.feedback, logMessage };
 }
 
 // Exported for testing
-export { parseDecisionBlock, runSupervisorQuery, validateDecision, PLAN_DECISIONS, REVIEW_DECISIONS };
+export { parseDecisionBlock, runSupervisorQuery, validateDecision, PLAN_DECISIONS, REVIEW_DECISIONS, MAX_CONCURRENT_SUPERVISORS };

--- a/server/src/supervisor.js
+++ b/server/src/supervisor.js
@@ -6,6 +6,9 @@ const SUPERVISOR_TIMEOUT = 60_000;
 const DECISION_START = '=== SUPERVISOR DECISION START ===';
 const DECISION_END = '=== SUPERVISOR DECISION END ===';
 
+const PLAN_DECISIONS = new Set(['APPROVE', 'REJECT', 'ESCALATE']);
+const REVIEW_DECISIONS = new Set(['RETRY', 'ESCALATE']);
+
 function parseDecisionBlock(output) {
   const startIdx = output.indexOf(DECISION_START);
   const endIdx = output.indexOf(DECISION_END);
@@ -26,6 +29,11 @@ function parseDecisionBlock(output) {
     decision: decisionMatch[1].trim().toUpperCase(),
     feedback,
   };
+}
+
+function validateDecision(result, validSet) {
+  if (!result || !validSet.has(result.decision)) return null;
+  return result;
 }
 
 function runSupervisorQuery(cli, model, prompt) {
@@ -87,7 +95,9 @@ ${DECISION_END}
 - REJECT if the plan has clear deficiencies that can be fixed by re-planning
 - ESCALATE if you are uncertain or the task needs human judgement`;
 
-  const result = await runSupervisorQuery(cli, model, prompt);
+  const raw = await runSupervisorQuery(cli, model, prompt);
+  const result = validateDecision(raw, PLAN_DECISIONS)
+    || { decision: 'ESCALATE', feedback: `Invalid supervisor decision: ${raw?.decision || 'none'}` };
   store.appendLog(task.id, `Supervisor evaluated plan: ${result.decision}${result.feedback ? ' — ' + result.feedback : ''}`);
   return result;
 }
@@ -120,10 +130,12 @@ ${DECISION_END}
 - RETRY if the issues are fixable by an AI implementor with better instructions
 - ESCALATE if the issues require architectural decisions, clarification, or human judgement`;
 
-  const result = await runSupervisorQuery(cli, model, prompt);
+  const raw = await runSupervisorQuery(cli, model, prompt);
+  const result = validateDecision(raw, REVIEW_DECISIONS)
+    || { decision: 'ESCALATE', feedback: `Invalid supervisor decision: ${raw?.decision || 'none'}` };
   store.appendLog(task.id, `Supervisor evaluated review failure: ${result.decision}${result.feedback ? ' — ' + result.feedback : ''}`);
   return { decision: result.decision, enhancedFeedback: result.feedback };
 }
 
 // Exported for testing
-export { parseDecisionBlock, runSupervisorQuery };
+export { parseDecisionBlock, runSupervisorQuery, validateDecision, PLAN_DECISIONS, REVIEW_DECISIONS };

--- a/server/src/supervisor.js
+++ b/server/src/supervisor.js
@@ -13,13 +13,18 @@ function parseDecisionBlock(output) {
 
   const block = output.slice(startIdx + DECISION_START.length, endIdx).trim();
   const decisionMatch = block.match(/^DECISION:\s*(.+)/m);
-  const feedbackMatch = block.match(/^(?:FEEDBACK|ENHANCED_FEEDBACK):\s*([\s\S]*?)$/m);
-
   if (!decisionMatch) return null;
+
+  // Extract feedback: find the label and take everything after it to end of block.
+  // Using slice instead of a regex with $ avoids multi-line truncation issues.
+  const feedbackLabelMatch = block.match(/^(?:FEEDBACK|ENHANCED_FEEDBACK):\s*/m);
+  const feedback = feedbackLabelMatch
+    ? block.slice(feedbackLabelMatch.index + feedbackLabelMatch[0].length).trim()
+    : '';
 
   return {
     decision: decisionMatch[1].trim().toUpperCase(),
-    feedback: feedbackMatch ? feedbackMatch[1].trim() : '',
+    feedback,
   };
 }
 

--- a/server/src/supervisor.js
+++ b/server/src/supervisor.js
@@ -1,6 +1,8 @@
 import { execFile } from 'node:child_process';
 
 const SUPERVISOR_TIMEOUT = 60_000;
+const SLOT_ACQUIRE_TIMEOUT = 30_000;
+const MAX_QUEUE_DEPTH = 20;
 
 const DECISION_START = '=== SUPERVISOR DECISION START ===';
 const DECISION_END = '=== SUPERVISOR DECISION END ===';
@@ -13,21 +15,41 @@ let activeSupervisors = 0;
 const supervisorQueue = [];
 
 function acquireSupervisorSlot() {
-  return new Promise((resolve) => {
+  if (supervisorQueue.length >= MAX_QUEUE_DEPTH) {
+    return Promise.reject(new Error(`Supervisor queue full (${MAX_QUEUE_DEPTH} pending). Try again later.`));
+  }
+  return new Promise((resolve, reject) => {
     if (activeSupervisors < MAX_CONCURRENT_SUPERVISORS) {
       activeSupervisors++;
       resolve();
     } else {
-      supervisorQueue.push(resolve);
+      const timer = setTimeout(() => {
+        const idx = supervisorQueue.indexOf(entry);
+        if (idx !== -1) supervisorQueue.splice(idx, 1);
+        reject(new Error(`Supervisor slot acquisition timed out after ${SLOT_ACQUIRE_TIMEOUT}ms`));
+      }, SLOT_ACQUIRE_TIMEOUT);
+      const entry = { resolve, reject, timer };
+      supervisorQueue.push(entry);
     }
   });
 }
 
 function releaseSupervisorSlot() {
-  activeSupervisors--;
   if (supervisorQueue.length > 0) {
-    activeSupervisors++;
-    supervisorQueue.shift()();
+    const entry = supervisorQueue.shift();
+    clearTimeout(entry.timer);
+    entry.resolve();
+  } else {
+    activeSupervisors--;
+  }
+}
+
+function resetSupervisorState() {
+  activeSupervisors = 0;
+  while (supervisorQueue.length > 0) {
+    const entry = supervisorQueue.shift();
+    clearTimeout(entry.timer);
+    entry.reject(new Error('Supervisor state reset'));
   }
 }
 
@@ -58,8 +80,18 @@ function validateDecision(result, validSet) {
   return result;
 }
 
-async function runSupervisorQuery(cli, model, prompt) {
+function sanitizeStderr(stderr) {
+  if (!stderr) return '';
+  // Strip potential secrets/internal details from stderr before storing
+  return stderr
+    .replace(/sk-[a-zA-Z0-9_-]{10,}/g, 'sk-***')
+    .replace(/key[=:]\s*\S+/gi, 'key=***')
+    .slice(0, 500);
+}
+
+async function runSupervisorQuery(cli, model, prompt, context = {}) {
   await acquireSupervisorSlot();
+  const startTime = Date.now();
   try {
     return await new Promise((resolve) => {
       let cliCmd, args;
@@ -80,14 +112,17 @@ async function runSupervisorQuery(cli, model, prompt) {
         encoding: 'utf-8',
         maxBuffer: 1024 * 1024,
       }, (err, stdout, stderr) => {
+        const elapsed = Date.now() - startTime;
         if (err) {
-          const detail = stderr ? `${err.message}\nstderr: ${stderr}` : err.message;
-          return resolve({ decision: 'ESCALATE', feedback: `Supervisor error: ${detail}` });
+          const safeStderr = sanitizeStderr(stderr);
+          const detail = safeStderr ? `${err.message}\nstderr: ${safeStderr}` : err.message;
+          console.error('Supervisor subprocess failed', { ...context, cli, elapsed, errorCode: err.code });
+          return resolve({ decision: 'ESCALATE', feedback: `Supervisor error: ${detail}`, _isError: true });
         }
         const parsed = parseDecisionBlock(stdout);
         if (!parsed) {
-          console.error('Supervisor returned unparseable output:', stdout?.slice(0, 500));
-          return resolve({ decision: 'ESCALATE', feedback: 'Supervisor returned unparseable output' });
+          console.error('Supervisor returned unparseable output', { ...context, cli, elapsed, output: stdout?.slice(0, 500) });
+          return resolve({ decision: 'ESCALATE', feedback: 'Supervisor returned unparseable output', _isError: true });
         }
         resolve(parsed);
       });
@@ -127,7 +162,7 @@ ${DECISION_END}
 - REJECT if the plan has clear deficiencies that can be fixed by re-planning
 - ESCALATE if you are uncertain or the task needs human judgement`;
 
-  const raw = await runSupervisorQuery(cli, model, prompt);
+  const raw = await runSupervisorQuery(cli, model, prompt, { taskId: task.id, stage: 'plan' });
   const result = validateDecision(raw, PLAN_DECISIONS)
     || { decision: 'ESCALATE', feedback: `Invalid supervisor decision: ${raw?.decision || 'none'}` };
   const logMessage = `Supervisor evaluated plan: ${result.decision}${result.feedback ? ' — ' + result.feedback : ''}`;
@@ -162,12 +197,12 @@ ${DECISION_END}
 - RETRY if the issues are fixable by an AI implementor with better instructions
 - ESCALATE if the issues require architectural decisions, clarification, or human judgement`;
 
-  const raw = await runSupervisorQuery(cli, model, prompt);
+  const raw = await runSupervisorQuery(cli, model, prompt, { taskId: task.id, stage: 'review' });
   const result = validateDecision(raw, REVIEW_DECISIONS)
     || { decision: 'ESCALATE', feedback: `Invalid supervisor decision: ${raw?.decision || 'none'}` };
   const logMessage = `Supervisor evaluated review failure: ${result.decision}${result.feedback ? ' — ' + result.feedback : ''}`;
-  return { decision: result.decision, enhancedFeedback: result.feedback, logMessage };
+  return { decision: result.decision, feedback: result.feedback, logMessage };
 }
 
 // Exported for testing
-export { parseDecisionBlock, runSupervisorQuery, validateDecision, PLAN_DECISIONS, REVIEW_DECISIONS, MAX_CONCURRENT_SUPERVISORS };
+export { parseDecisionBlock, runSupervisorQuery, validateDecision, PLAN_DECISIONS, REVIEW_DECISIONS, MAX_CONCURRENT_SUPERVISORS, resetSupervisorState };

--- a/server/src/supervisor.js
+++ b/server/src/supervisor.js
@@ -153,9 +153,17 @@ async function runSupervisorQuery(cli, model, prompt, context = {}) {
   }
 }
 
+function getSupervisorCliModel(settings) {
+  const sup = settings.agents?.supervisor;
+  const plan = settings.agents?.planners;
+  return {
+    cli: sup?.cli || plan?.cli || 'claude',
+    model: sup?.model ?? plan?.model ?? '',
+  };
+}
+
 export async function evaluatePlan(task, settings) {
-  const cli = settings.agents?.planners?.cli || 'claude';
-  const model = settings.agents?.planners?.model || '';
+  const { cli, model } = getSupervisorCliModel(settings);
 
   const prompt = `You are a supervisor agent evaluating a generated plan for quality and completeness.
 
@@ -191,8 +199,7 @@ ${DECISION_END}
 }
 
 export async function evaluateReviewFailure(task, reviewText, criticalIssues, settings) {
-  const cli = settings.agents?.planners?.cli || 'claude';
-  const model = settings.agents?.planners?.model || '';
+  const { cli, model } = getSupervisorCliModel(settings);
 
   const prompt = `You are a supervisor agent analyzing a failed code review to decide the next action.
 

--- a/server/src/supervisor.js
+++ b/server/src/supervisor.js
@@ -38,9 +38,10 @@ function releaseSupervisorSlot() {
   if (supervisorQueue.length > 0) {
     const entry = supervisorQueue.shift();
     clearTimeout(entry.timer);
+    // Transfer the slot to the next waiter — don't decrement activeSupervisors
     entry.resolve();
   } else {
-    activeSupervisors--;
+    activeSupervisors = Math.max(0, activeSupervisors - 1);
   }
 }
 
@@ -86,12 +87,24 @@ function sanitizeStderr(stderr) {
   return stderr
     .replace(/sk-[a-zA-Z0-9_-]{10,}/g, 'sk-***')
     .replace(/key[=:]\s*\S+/gi, 'key=***')
+    .replace(/Bearer\s+\S+/gi, 'Bearer ***')
+    .replace(/ghp_[a-zA-Z0-9_]+/g, 'ghp_***')
+    .replace(/github_pat_[a-zA-Z0-9_]+/g, 'github_pat_***')
+    .replace(/AKIA[A-Z0-9]{16}/g, 'AKIA***')
+    .replace(/(token|password|secret)[=:]\s*\S+/gi, '$1=***')
     .slice(0, 500);
 }
 
+function stripDecisionMarkers(text) {
+  if (typeof text !== 'string') return text;
+  return text
+    .replaceAll(DECISION_START, '[MARKER STRIPPED]')
+    .replaceAll(DECISION_END, '[MARKER STRIPPED]');
+}
+
 async function runSupervisorQuery(cli, model, prompt, context = {}) {
-  await acquireSupervisorSlot();
   const startTime = Date.now();
+  await acquireSupervisorSlot();
   try {
     return await new Promise((resolve) => {
       let cliCmd, args;
@@ -138,12 +151,12 @@ export async function evaluatePlan(task, settings) {
 
   const prompt = `You are a supervisor agent evaluating a generated plan for quality and completeness.
 
-TASK: ${task.title}
-DESCRIPTION: ${task.description || 'No description provided.'}
+TASK: ${stripDecisionMarkers(task.title)}
+DESCRIPTION: ${stripDecisionMarkers(task.description || 'No description provided.')}
 PRIORITY: ${task.priority}
 
 GENERATED PLAN:
-${task.plan}
+${stripDecisionMarkers(task.plan)}
 
 Evaluate the plan on these criteria:
 1. Does it address the task requirements?
@@ -166,7 +179,7 @@ ${DECISION_END}
   const result = validateDecision(raw, PLAN_DECISIONS)
     || { decision: 'ESCALATE', feedback: `Invalid supervisor decision: ${raw?.decision || 'none'}` };
   const logMessage = `Supervisor evaluated plan: ${result.decision}${result.feedback ? ' — ' + result.feedback : ''}`;
-  return { ...result, logMessage };
+  return { decision: result.decision, feedback: result.feedback, logMessage };
 }
 
 export async function evaluateReviewFailure(task, reviewText, criticalIssues, settings) {
@@ -175,15 +188,15 @@ export async function evaluateReviewFailure(task, reviewText, criticalIssues, se
 
   const prompt = `You are a supervisor agent analyzing a failed code review to decide the next action.
 
-TASK: ${task.title}
-DESCRIPTION: ${task.description || 'No description provided.'}
+TASK: ${stripDecisionMarkers(task.title)}
+DESCRIPTION: ${stripDecisionMarkers(task.description || 'No description provided.')}
 REVIEW CYCLE: ${(task.reviewCycleCount || 0) + 1} of ${task.maxReviewCycles || 3}
 
 REVIEW OUTPUT:
-${reviewText}
+${stripDecisionMarkers(reviewText)}
 
 CRITICAL ISSUES:
-${criticalIssues}
+${stripDecisionMarkers(criticalIssues)}
 
 Decide whether the implementation should retry with enhanced guidance or if this needs human intervention.
 
@@ -205,4 +218,4 @@ ${DECISION_END}
 }
 
 // Exported for testing
-export { parseDecisionBlock, runSupervisorQuery, validateDecision, PLAN_DECISIONS, REVIEW_DECISIONS, MAX_CONCURRENT_SUPERVISORS, resetSupervisorState };
+export { parseDecisionBlock, runSupervisorQuery, validateDecision, stripDecisionMarkers, PLAN_DECISIONS, REVIEW_DECISIONS, MAX_CONCURRENT_SUPERVISORS, resetSupervisorState };

--- a/server/src/supervisor.js
+++ b/server/src/supervisor.js
@@ -1,0 +1,124 @@
+import { execFile } from 'node:child_process';
+import store from './store.js';
+
+const SUPERVISOR_TIMEOUT = 60_000;
+
+const DECISION_START = '=== SUPERVISOR DECISION START ===';
+const DECISION_END = '=== SUPERVISOR DECISION END ===';
+
+function parseDecisionBlock(output) {
+  const startIdx = output.indexOf(DECISION_START);
+  const endIdx = output.indexOf(DECISION_END);
+  if (startIdx === -1 || endIdx === -1 || endIdx <= startIdx) return null;
+
+  const block = output.slice(startIdx + DECISION_START.length, endIdx).trim();
+  const decisionMatch = block.match(/^DECISION:\s*(.+)/m);
+  const feedbackMatch = block.match(/^(?:FEEDBACK|ENHANCED_FEEDBACK):\s*([\s\S]*?)$/m);
+
+  if (!decisionMatch) return null;
+
+  return {
+    decision: decisionMatch[1].trim().toUpperCase(),
+    feedback: feedbackMatch ? feedbackMatch[1].trim() : '',
+  };
+}
+
+function runSupervisorQuery(cli, model, prompt) {
+  return new Promise((resolve) => {
+    const args = ['--print'];
+    if (model) args.push('--model', model);
+    args.push(prompt);
+
+    const cliCmd = cli === 'codex' ? 'codex' : 'claude';
+    const child = execFile(cliCmd, args, {
+      timeout: SUPERVISOR_TIMEOUT,
+      encoding: 'utf-8',
+      maxBuffer: 1024 * 1024,
+    }, (err, stdout) => {
+      if (err) {
+        return resolve({ decision: 'ESCALATE', feedback: `Supervisor error: ${err.message}` });
+      }
+      const parsed = parseDecisionBlock(stdout);
+      if (!parsed) {
+        return resolve({ decision: 'ESCALATE', feedback: 'Supervisor returned unparseable output' });
+      }
+      resolve(parsed);
+    });
+
+    // Extra safety: kill on timeout (execFile timeout sends SIGTERM)
+    child.on('error', () => {
+      resolve({ decision: 'ESCALATE', feedback: 'Supervisor process error' });
+    });
+  });
+}
+
+export async function evaluatePlan(task, settings) {
+  const cli = settings.agents?.planners?.cli || 'claude';
+  const model = settings.agents?.planners?.model || '';
+
+  const prompt = `You are a supervisor agent evaluating a generated plan for quality and completeness.
+
+TASK: ${task.title}
+DESCRIPTION: ${task.description || 'No description provided.'}
+PRIORITY: ${task.priority}
+
+GENERATED PLAN:
+${task.plan}
+
+Evaluate the plan on these criteria:
+1. Does it address the task requirements?
+2. Are the steps actionable and specific?
+3. Are risks and tests identified?
+4. Is the branch name reasonable?
+
+Respond ONLY in this exact format:
+
+${DECISION_START}
+DECISION: APPROVE or REJECT or ESCALATE
+FEEDBACK: (brief explanation of your decision, or specific issues if rejecting)
+${DECISION_END}
+
+- APPROVE if the plan is solid and ready for implementation
+- REJECT if the plan has clear deficiencies that can be fixed by re-planning
+- ESCALATE if you are uncertain or the task needs human judgement`;
+
+  const result = await runSupervisorQuery(cli, model, prompt);
+  store.appendLog(task.id, `Supervisor evaluated plan: ${result.decision}${result.feedback ? ' — ' + result.feedback : ''}`);
+  return result;
+}
+
+export async function evaluateReviewFailure(task, reviewText, criticalIssues, settings) {
+  const cli = settings.agents?.planners?.cli || 'claude';
+  const model = settings.agents?.planners?.model || '';
+
+  const prompt = `You are a supervisor agent analyzing a failed code review to decide the next action.
+
+TASK: ${task.title}
+DESCRIPTION: ${task.description || 'No description provided.'}
+REVIEW CYCLE: ${(task.reviewCycleCount || 0) + 1} of ${task.maxReviewCycles || 3}
+
+REVIEW OUTPUT:
+${reviewText}
+
+CRITICAL ISSUES:
+${criticalIssues}
+
+Decide whether the implementation should retry with enhanced guidance or if this needs human intervention.
+
+Respond ONLY in this exact format:
+
+${DECISION_START}
+DECISION: RETRY or ESCALATE
+ENHANCED_FEEDBACK: (if RETRY: specific, actionable instructions for the implementor to fix the critical issues. If ESCALATE: explanation of why human input is needed)
+${DECISION_END}
+
+- RETRY if the issues are fixable by an AI implementor with better instructions
+- ESCALATE if the issues require architectural decisions, clarification, or human judgement`;
+
+  const result = await runSupervisorQuery(cli, model, prompt);
+  store.appendLog(task.id, `Supervisor evaluated review failure: ${result.decision}${result.feedback ? ' — ' + result.feedback : ''}`);
+  return { decision: result.decision, enhancedFeedback: result.feedback };
+}
+
+// Exported for testing
+export { parseDecisionBlock, runSupervisorQuery };

--- a/server/src/supervisor.js
+++ b/server/src/supervisor.js
@@ -104,44 +104,52 @@ function stripDecisionMarkers(text) {
 
 async function runSupervisorQuery(cli, model, prompt, context = {}) {
   const startTime = Date.now();
+  let slotAcquired = false;
   await acquireSupervisorSlot();
+  slotAcquired = true;
   try {
-    return await new Promise((resolve) => {
+    return await new Promise((resolve, reject) => {
       let cliCmd, args;
       if (cli === 'codex') {
         cliCmd = 'codex';
         args = ['exec', '--sandbox', 'read-only'];
         if (model) args.push('-m', model);
-        args.push(prompt);
+        args.push('-'); // read from stdin
       } else {
         cliCmd = 'claude';
         args = ['--print'];
         if (model) args.push('--model', model);
-        args.push(prompt);
+        args.push('-'); // read from stdin
       }
 
-      execFile(cliCmd, args, {
-        timeout: SUPERVISOR_TIMEOUT,
-        encoding: 'utf-8',
-        maxBuffer: 1024 * 1024,
-      }, (err, stdout, stderr) => {
-        const elapsed = Date.now() - startTime;
-        if (err) {
-          const safeStderr = sanitizeStderr(stderr);
-          const detail = safeStderr ? `${err.message}\nstderr: ${safeStderr}` : err.message;
-          console.error('Supervisor subprocess failed', { ...context, cli, elapsed, errorCode: err.code });
-          return resolve({ decision: 'ESCALATE', feedback: `Supervisor error: ${detail}`, _isError: true });
-        }
-        const parsed = parseDecisionBlock(stdout);
-        if (!parsed) {
-          console.error('Supervisor returned unparseable output', { ...context, cli, elapsed, output: stdout?.slice(0, 500) });
-          return resolve({ decision: 'ESCALATE', feedback: 'Supervisor returned unparseable output', _isError: true });
-        }
-        resolve(parsed);
-      });
+      try {
+        const child = execFile(cliCmd, args, {
+          timeout: SUPERVISOR_TIMEOUT,
+          encoding: 'utf-8',
+          maxBuffer: 1024 * 1024,
+        }, (err, stdout, stderr) => {
+          const elapsed = Date.now() - startTime;
+          if (err) {
+            const safeStderr = sanitizeStderr(stderr);
+            const detail = safeStderr ? `${err.message}\nstderr: ${safeStderr}` : err.message;
+            console.error('Supervisor subprocess failed', { ...context, cli, elapsed, errorCode: err.code });
+            return resolve({ decision: 'ESCALATE', feedback: `Supervisor error: ${detail}` });
+          }
+          const parsed = parseDecisionBlock(stdout);
+          if (!parsed) {
+            console.error('Supervisor returned unparseable output', { ...context, cli, elapsed, output: stdout?.slice(0, 500) });
+            return resolve({ decision: 'ESCALATE', feedback: 'Supervisor returned unparseable output' });
+          }
+          resolve(parsed);
+        });
+        child.stdin.write(prompt);
+        child.stdin.end();
+      } catch (err) {
+        reject(err);
+      }
     });
   } finally {
-    releaseSupervisorSlot();
+    if (slotAcquired) releaseSupervisorSlot();
   }
 }
 

--- a/server/src/supervisor.test.js
+++ b/server/src/supervisor.test.js
@@ -117,6 +117,20 @@ DECISION: APPROVE
     expect(result.decision).toBe('APPROVE');
     expect(result.feedback).toBe('');
   });
+
+  test('finds the end marker that belongs to the matched decision block', () => {
+    const output = `Preamble mentions === SUPERVISOR DECISION END === before the real block.
+=== SUPERVISOR DECISION START ===
+DECISION: APPROVE
+FEEDBACK: Use the end marker after the matched start marker.
+=== SUPERVISOR DECISION END ===`;
+
+    const result = parseDecisionBlock(output);
+    expect(result).toEqual({
+      decision: 'APPROVE',
+      feedback: 'Use the end marker after the matched start marker.',
+    });
+  });
 });
 
 describe('decision validation', () => {

--- a/server/src/supervisor.test.js
+++ b/server/src/supervisor.test.js
@@ -73,6 +73,41 @@ FEEDBACK: No decision line present.
     expect(parseDecisionBlock(output)).toBeNull();
   });
 
+  test('captures multi-line feedback without truncation', () => {
+    const output = `=== SUPERVISOR DECISION START ===
+DECISION: REJECT
+FEEDBACK: The plan has several issues:
+1. Missing error handling for the API endpoint
+2. No test coverage for edge cases
+3. The branch name does not follow conventions
+
+Please address all of the above before re-submitting.
+=== SUPERVISOR DECISION END ===`;
+
+    const result = parseDecisionBlock(output);
+    expect(result.decision).toBe('REJECT');
+    expect(result.feedback).toContain('1. Missing error handling');
+    expect(result.feedback).toContain('2. No test coverage');
+    expect(result.feedback).toContain('3. The branch name');
+    expect(result.feedback).toContain('Please address all of the above');
+  });
+
+  test('captures multi-line ENHANCED_FEEDBACK without truncation', () => {
+    const output = `=== SUPERVISOR DECISION START ===
+DECISION: RETRY
+ENHANCED_FEEDBACK: Fix the following critical issues:
+- The null check in parseConfig is missing
+- Add validation for empty inputs
+- Ensure the error message is user-friendly
+=== SUPERVISOR DECISION END ===`;
+
+    const result = parseDecisionBlock(output);
+    expect(result.decision).toBe('RETRY');
+    expect(result.feedback).toContain('The null check in parseConfig is missing');
+    expect(result.feedback).toContain('Add validation for empty inputs');
+    expect(result.feedback).toContain('Ensure the error message is user-friendly');
+  });
+
   test('returns empty feedback when no FEEDBACK line', () => {
     const output = `=== SUPERVISOR DECISION START ===
 DECISION: APPROVE

--- a/server/src/supervisor.test.js
+++ b/server/src/supervisor.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, test } from 'vitest';
+
+import { parseDecisionBlock } from './supervisor.js';
+
+describe('supervisor decision parsing', () => {
+  test('parses APPROVE decision with feedback', () => {
+    const output = `Some preamble text...
+=== SUPERVISOR DECISION START ===
+DECISION: APPROVE
+FEEDBACK: Plan is well-structured and addresses all requirements.
+=== SUPERVISOR DECISION END ===
+Some trailing text...`;
+
+    const result = parseDecisionBlock(output);
+    expect(result).toEqual({
+      decision: 'APPROVE',
+      feedback: 'Plan is well-structured and addresses all requirements.',
+    });
+  });
+
+  test('parses REJECT decision', () => {
+    const output = `=== SUPERVISOR DECISION START ===
+DECISION: REJECT
+FEEDBACK: Missing test coverage for edge cases.
+=== SUPERVISOR DECISION END ===`;
+
+    const result = parseDecisionBlock(output);
+    expect(result.decision).toBe('REJECT');
+    expect(result.feedback).toBe('Missing test coverage for edge cases.');
+  });
+
+  test('parses ESCALATE decision', () => {
+    const output = `=== SUPERVISOR DECISION START ===
+DECISION: ESCALATE
+FEEDBACK: Task requires architectural decision beyond scope.
+=== SUPERVISOR DECISION END ===`;
+
+    const result = parseDecisionBlock(output);
+    expect(result.decision).toBe('ESCALATE');
+  });
+
+  test('parses RETRY decision with ENHANCED_FEEDBACK', () => {
+    const output = `=== SUPERVISOR DECISION START ===
+DECISION: RETRY
+ENHANCED_FEEDBACK: Fix the null check in parseConfig and add validation for empty inputs.
+=== SUPERVISOR DECISION END ===`;
+
+    const result = parseDecisionBlock(output);
+    expect(result.decision).toBe('RETRY');
+    expect(result.feedback).toContain('Fix the null check');
+  });
+
+  test('normalizes decision to uppercase', () => {
+    const output = `=== SUPERVISOR DECISION START ===
+DECISION: approve
+FEEDBACK: Looks good.
+=== SUPERVISOR DECISION END ===`;
+
+    const result = parseDecisionBlock(output);
+    expect(result.decision).toBe('APPROVE');
+  });
+
+  test('returns null for missing markers', () => {
+    expect(parseDecisionBlock('no markers here')).toBeNull();
+    expect(parseDecisionBlock('=== SUPERVISOR DECISION START === no end')).toBeNull();
+  });
+
+  test('returns null for missing DECISION line', () => {
+    const output = `=== SUPERVISOR DECISION START ===
+FEEDBACK: No decision line present.
+=== SUPERVISOR DECISION END ===`;
+
+    expect(parseDecisionBlock(output)).toBeNull();
+  });
+
+  test('returns empty feedback when no FEEDBACK line', () => {
+    const output = `=== SUPERVISOR DECISION START ===
+DECISION: APPROVE
+=== SUPERVISOR DECISION END ===`;
+
+    const result = parseDecisionBlock(output);
+    expect(result.decision).toBe('APPROVE');
+    expect(result.feedback).toBe('');
+  });
+});

--- a/server/src/supervisor.test.js
+++ b/server/src/supervisor.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 
-import { parseDecisionBlock } from './supervisor.js';
+import { parseDecisionBlock, validateDecision, PLAN_DECISIONS, REVIEW_DECISIONS } from './supervisor.js';
 
 describe('supervisor decision parsing', () => {
   test('parses APPROVE decision with feedback', () => {
@@ -116,5 +116,36 @@ DECISION: APPROVE
     const result = parseDecisionBlock(output);
     expect(result.decision).toBe('APPROVE');
     expect(result.feedback).toBe('');
+  });
+});
+
+describe('decision validation', () => {
+  test('accepts valid plan decisions', () => {
+    for (const decision of ['APPROVE', 'REJECT', 'ESCALATE']) {
+      const result = { decision, feedback: 'ok' };
+      expect(validateDecision(result, PLAN_DECISIONS)).toBe(result);
+    }
+  });
+
+  test('rejects invalid plan decisions', () => {
+    expect(validateDecision({ decision: 'RETRY', feedback: '' }, PLAN_DECISIONS)).toBeNull();
+    expect(validateDecision({ decision: 'GARBAGE', feedback: '' }, PLAN_DECISIONS)).toBeNull();
+  });
+
+  test('accepts valid review decisions', () => {
+    for (const decision of ['RETRY', 'ESCALATE']) {
+      const result = { decision, feedback: 'ok' };
+      expect(validateDecision(result, REVIEW_DECISIONS)).toBe(result);
+    }
+  });
+
+  test('rejects invalid review decisions', () => {
+    expect(validateDecision({ decision: 'APPROVE', feedback: '' }, REVIEW_DECISIONS)).toBeNull();
+    expect(validateDecision({ decision: 'REJECT', feedback: '' }, REVIEW_DECISIONS)).toBeNull();
+  });
+
+  test('returns null for null or missing decision', () => {
+    expect(validateDecision(null, PLAN_DECISIONS)).toBeNull();
+    expect(validateDecision({ feedback: 'no decision field' }, PLAN_DECISIONS)).toBeNull();
   });
 });

--- a/server/src/workflow.js
+++ b/server/src/workflow.js
@@ -44,7 +44,10 @@ export function reviewShouldPass(reviewResult) {
 
 export function isMaxReviewCyclesBlocker(blockedReason) {
   if (typeof blockedReason !== 'string') return false;
-  return /^Reached maximum review cycles(?: \(\d+\))?/i.test(blockedReason.trim());
+  const trimmed = blockedReason.trim();
+  return /^Reached maximum review cycles(?: \(\d+\))?/i.test(trimmed)
+    || /^Supervisor exhausted \d+ extension/i.test(trimmed)
+    || /^Supervisor escalated/i.test(trimmed);
 }
 
 export function resolveTaskMaxReviewCycles(task, fallback = 3) {


### PR DESCRIPTION
## Summary

Add an Autopilot mode with a Supervisor Agent that auto-approves plans and makes intelligent retry decisions on review failures, reducing human intervention in the task pipeline.

## Key Changes

- server/src/supervisor.js (NEW — supervisor evaluation logic using claude --print for plan approval and review failure analysis)                                                                                - server/src/config.js (add autopilotMode setting to defaults, normalization, and validation)
- server/src/orchestrator.js (integrate supervisor at plan-complete and review-failure decision points)  - client/src/App.jsx (add autopilot mode selector to Settings modal General tab)
- server/src/supervisor.test.js (NEW — unit tests for supervisor module)  - server/src/config.test.js (add tests for autopilotMode setting)
- server/src/orchestrator.test.js (add tests for supervisor integration paths)

## Review

- Verdict: N/A
- Summary: Changed files: server/src/supervisor.js (new), server/src/supervisor.test.js (new), server/src/supervisor-integration.test.js (new), server/src/orchestrator.js, server/src/orchestrator.test.js, server/src/config.js, server/src/config.test.js, server/src/index.js, client/src/App.jsx, client/src/useFactory.js, plus lock file churn. The feature is well-architected: the supervisor module is clean with  fail-safe-to-ESCALATE semantics, decision parsing is robust with multi-line feedback support, config validation is thorough, the UI toggle is simple, and the orchestrator integration includes race condition guards and   a hard cap on cycle extensions. The main gaps are silent catch blocks and missing orchestrator-level integration tests for the supervisor paths.  === REVIEW END ===
- Minor issues: supervisor.js:62-64 — Potential double-resolve in runSupervisorQuery (confidence: 80): If execFile fails to spawn the process, both the execFile callback (with err) and the child.on('error') handler fire, calling resolve() twice. Promise silently ignores the second call so it won't crash, but it's a latent bug pattern. Fix: Track res lution s ate with a let resolved = fals  guard, or remove the child.on('error') handler since execFile's callback alr ady handles all error paths (spawn fa lure,  imeout exit code).                                                                                                                                 - orchestrator.js:906 — Silent .catch(() => {}) swallows errors without logging (confidence: 85): The plan evaluation catch block and the two review-failure catch blocks (lines 906, 1137, 1195 approx.) silently swallow  errors. The fail-safe behavior is correct (leave in awaiting_approval / block / retry with raw issu s), but there's zero observability in o why the supervisor  all failed. Fix: Add console.error('Supervisor evaluation  failed:', err.message) in each cat h block.                                                                                                                                                                               - orchestrator.test.js — No integration tests for supervisor decision paths in orchestrator (confidence: 78): The orchestrator test only asserts MAX_SUPERVISOR_EXTENSIONS is a constant. There are no tests for the actual orchestrator behavior: plan auto-approval triggering, review failure supervisor routing, rac   ondition guard, or the hard-cap exten ion logic. The supervisor-integration.test.js tests th supervi or module in isol ti n but no  how the  chestrator consumes i . Fix: Add orch str tor-level tests that mock supervisor.js expo ts and config.js's loadSettings to verify: (1) onPla Complete calls evaluatePlan when mode != manual, (2) review failure paths r ute th ough supervi or in autopilot, (3) the ext nsion hard c p blocks after MAX_SUPERVISOR_EXTENSIONS.