### PR TITLE
[T-185C2E] Git Worktree

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ The generated plan is shown in the dashboard so the developer can approve it bef
   <img src="https://raw.githubusercontent.com/stilero/bankan/HEAD/docs/images/workflow/implementing_task.png" alt="Ban Kan implementation stage showing the Stripe payments task being actively worked on by an agent" />
 </p>
 
-After approval, the implementor agent creates its workspace, writes the code, and reports progress live in the UI.
+After approval, the implementor agent creates or reuses a task-specific Git worktree, writes the code there, and reports progress live in the UI.
 
 ### 5. Review stage
 
@@ -296,7 +296,7 @@ Multiple tasks can run in parallel across different agents.
 Run multiple planning, implementation, and review agents simultaneously.
 
 ### Local-first workflow
-Repositories stay on your machine. Agents operate directly on local clones and workspaces.
+Repositories stay on your machine. Agents operate directly on your local repository checkouts and per-task Git worktrees.
 
 ### Human approval gates
 Developers approve plans before implementation begins.
@@ -305,7 +305,7 @@ Developers approve plans before implementation begins.
 Open the terminal of any running agent and take control when needed.
 
 ### VS Code workspace support
-Open a task workspace directly from the dashboard.
+Open a task worktree directly from the dashboard.
 
 ### PR automation
 Configure GitHub settings to automatically create pull requests.

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -90,6 +90,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -446,6 +447,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -469,6 +471,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1378,8 +1381,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -1622,7 +1624,8 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-5.5.0.tgz",
       "integrity": "sha512-hqJHYaQb5OptNunnyAnkHyM8aCjZ1MEIDTQu1iIbbTD/xops91NB5yq1ZK/dC2JDbVWtF23zUtl9JE2NqwT87A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -1650,7 +1653,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -1664,7 +1666,6 @@
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -1742,6 +1743,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1969,7 +1971,6 @@
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -1979,8 +1980,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2551,6 +2551,7 @@
       "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.1.0",
         "data-urls": "^5.0.0",
@@ -2647,7 +2648,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -2915,7 +2915,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -2940,6 +2939,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -2952,6 +2952,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -2965,8 +2966,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -3395,6 +3395,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3478,6 +3479,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/client/src/KanbanBoard.jsx
+++ b/client/src/KanbanBoard.jsx
@@ -41,7 +41,7 @@ const COLUMNS = [
         <path d='M3.5 13h9' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1.5' />
       </StageIcon>
     ),
-    statuses: ['workspace_setup', 'planning', 'awaiting_approval'],
+    statuses: ['planning', 'awaiting_approval'],
     agentPrefix: 'plan',
     color: 'var(--steel2)',
   },
@@ -55,7 +55,7 @@ const COLUMNS = [
         <path d='m3.5 10.5 2 2' fill='none' stroke='currentColor' strokeLinecap='round' strokeWidth='1.5' />
       </StageIcon>
     ),
-    statuses: ['queued', 'implementing'],
+    statuses: ['workspace_setup', 'queued', 'implementing'],
     agentPrefix: 'imp',
     color: 'var(--green)',
   },

--- a/client/src/ReportsModal.jsx
+++ b/client/src/ReportsModal.jsx
@@ -168,7 +168,8 @@ export default function ReportsModal({ tasks, repos, onClose }) {
       if (t.status === 'done') counts.done++;
       else if (t.status === 'implementing') counts.implementing++;
       else if (t.status === 'review' || t.status === 'awaiting_approval') counts.review++;
-      else if (t.status === 'planning' || t.status === 'workspace_setup') counts.planning++;
+      else if (t.status === 'planning') counts.planning++;
+      else if (t.status === 'workspace_setup') counts.implementing++;
       else if (t.status === 'blocked') counts.blocked++;
       else counts.other++;
     }

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -5,14 +5,14 @@ This document defines the expected end-to-end task lifecycle for AI Factory.
 ## Core Flow
 
 1. A user creates a task with a repository, short title, and description.
-2. Before planning begins, the app creates a task-specific workspace folder at `<workspaceRoot>/<taskId>` and checks out the selected repository there.
-3. A planner agent runs inside that task workspace and produces a plan.
+2. During planning, the planner runs in the selected repository checkout. No task worktree is created yet.
+3. After plan approval, the app creates or reuses a task-specific Git worktree at `<workspaceRoot>/<taskId>` on the planned branch.
 4. The user can inspect the plan, approve it, or send feedback to revise/replan it.
-5. After approval, an implementor agent works in the same task workspace and on the planned branch.
-6. After implementation, a reviewer agent reviews the same workspace.
+5. The implementor agent works in that task worktree on the planned branch.
+6. After implementation, a reviewer agent reviews the same task worktree.
 7. If review fails, the task returns to implementation with reviewer feedback.
 8. Review/implementation retries are capped at 3 failed review cycles. After that, the task is blocked and awaits human input.
-9. If review passes, the app creates a pull request from the task workspace, deletes the local task workspace, and then marks the task as done.
+9. If review passes, the app creates a pull request from the task worktree, removes that worktree, and then marks the task as done.
 
 ## Control Rules
 
@@ -21,12 +21,12 @@ This document defines the expected end-to-end task lifecycle for AI Factory.
 - A task can be blocked at any stage and should be clearly shown as awaiting human input.
 - Blocked tasks appear at the top of their owning column.
 - A task can be paused, resumed, retried, or aborted.
-- Aborting a task stops automation and deletes its task workspace.
+- Aborting a task stops automation and removes its task worktree.
 
 ## Status Semantics
 
 - `workspace_setup`, `planning`, `awaiting_approval` belong to the planning column.
 - `queued`, `implementing` belong to the implementation column.
 - `review` belongs to the review column.
-- `done` means PR creation and workspace cleanup both succeeded.
+- `done` means PR creation and worktree cleanup both succeeded.
 - `blocked` and `paused` are overlay states and retain the task's owning column context.

--- a/docs/task-flow.md
+++ b/docs/task-flow.md
@@ -25,8 +25,8 @@ This document defines the expected end-to-end task lifecycle for AI Factory.
 
 ## Status Semantics
 
-- `workspace_setup`, `planning`, `awaiting_approval` belong to the planning column.
-- `queued`, `implementing` belong to the implementation column.
+- `planning`, `awaiting_approval` belong to the planning column.
+- `workspace_setup`, `queued`, `implementing` belong to the implementation column.
 - `review` belongs to the review column.
 - `done` means PR creation and worktree cleanup both succeeded.
 - `blocked` and `paused` are overlay states and retain the task's owning column context.

--- a/package-lock.json
+++ b/package-lock.json
@@ -372,6 +372,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1299,6 +1300,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -2972,6 +2972,7 @@
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -3080,6 +3081,7 @@
       "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "2.1.9",
         "@vitest/mocker": "2.1.9",

--- a/server/src/agents.test.js
+++ b/server/src/agents.test.js
@@ -449,7 +449,7 @@ RISKS:
       kill: vi.fn(),
     });
 
-    const validCwd = new URL('.', import.meta.url).pathname;
+    const validCwd = decodeURIComponent(new URL('.', import.meta.url).pathname);
     agent.spawn(validCwd, 'echo test');
 
     const [shell, args] = spawnSpy.mock.calls[0];

--- a/server/src/config.js
+++ b/server/src/config.js
@@ -110,6 +110,7 @@ Key rules:
 - **No Laziness**: Find root causes. No temporary fixes. Senior developer standards.
 - **Minimal Impact**: Only touch what's necessary. No side effects with new bugs.
 - **Demand Elegance (Balanced)**: For non-trivial changes, pause and ask "is there a more elegant way?" Skip this for simple, obvious fixes — don't over-engineer.
+- Implementation runs inside a task-specific Git worktree that Ban Kan prepares after plan approval.
 
 ## Mandatory Test Verification
 - Follow TDD when practical: create or update the failing test first, implement the change second, then rerun the suite.

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -7,6 +7,7 @@ import { homedir } from 'node:os';
 import { resolve, dirname as pathDirname, join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
+import { simpleGit } from 'simple-git';
 import config, { loadSettings, saveSettings, validateSettings, getWorkspacesDir, getRuntimeStatePaths } from './config.js';
 import { getGithubCapabilities } from './capabilities.js';
 import store from './store.js';
@@ -19,6 +20,7 @@ import {
   stageToRetryStatus,
 } from './workflow.js';
 import { createSessionEntry } from './sessionHistory.js';
+import { removeTaskWorktree } from './orchestrator.js';
 
 const app = express();
 app.use(cors());
@@ -61,16 +63,12 @@ function resolveRetryStatus(task) {
   return stageToRetryStatus(task, { planningDisabled, liveAgent });
 }
 
-export function approveMaxReviewBlocker(taskId) {
+export async function approveMaxReviewBlocker(taskId) {
   const task = store.getTask(taskId);
   const updates = buildMaxReviewBlockerApprovalUpdate(task);
   if (!updates) return false;
   if (task?.workspacePath) {
-    try {
-      rmSync(task.workspacePath, { recursive: true, force: true, maxRetries: 3, retryDelay: 500 });
-    } catch (err) {
-      console.warn(`Could not remove workspace ${task.workspacePath}: ${err.message}`);
-    }
+    await removeTaskWorktree(task);
   }
   store.updateTask(taskId, updates);
   store.appendLog(taskId, 'Human override: approved task to done after max review cycles.');
@@ -86,6 +84,73 @@ function extendMaxReviewBlocker(taskId) {
   store.appendLog(taskId, `Human override: increased review limit to ${updates.maxReviewCycles}.`);
   bus.emit('max-review-blocker:extended', { taskId, maxReviewCycles: updates.maxReviewCycles });
   return true;
+}
+
+function parseWorktreeList(rawOutput) {
+  const worktrees = new Set();
+  if (typeof rawOutput !== 'string' || !rawOutput.trim()) return worktrees;
+
+  for (const block of rawOutput.trim().split('\n\n')) {
+    for (const line of block.split('\n')) {
+      if (line.startsWith('worktree ')) {
+        worktrees.add(line.slice('worktree '.length).trim());
+      }
+    }
+  }
+
+  return worktrees;
+}
+
+export async function cleanupOrphanTaskWorktrees() {
+  const workspacesDir = getWorkspacesDir();
+  if (!existsSync(workspacesDir)) return;
+
+  let entries;
+  try {
+    entries = readdirSync(workspacesDir);
+  } catch {
+    entries = [];
+  }
+
+  const tasks = store.getAllTasks();
+  const activeWorkspacePaths = new Set(
+    tasks
+      .filter(task => task?.workspacePath && !['done', 'aborted', 'awaiting_human_review'].includes(task.status))
+      .map(task => task.workspacePath)
+  );
+  const referencedWorkspacePaths = new Set(
+    tasks
+      .map(task => task?.workspacePath)
+      .filter(Boolean)
+  );
+  const repoPaths = [...new Set(tasks.map(task => task?.repoPath).filter(Boolean))];
+  const registeredWorktrees = new Set();
+
+  for (const repoPath of repoPaths) {
+    try {
+      const output = await simpleGit(repoPath).raw(['worktree', 'list', '--porcelain']);
+      for (const worktreePath of parseWorktreeList(output)) {
+        registeredWorktrees.add(worktreePath);
+      }
+    } catch {
+      // Ignore repo inspection failures and avoid deleting paths conservatively.
+    }
+  }
+
+  for (const entry of entries) {
+    if (!entry.startsWith('T-')) continue;
+    const entryPath = join(workspacesDir, entry);
+    if (activeWorkspacePaths.has(entryPath)) continue;
+    if (referencedWorkspacePaths.has(entryPath)) continue;
+    if (registeredWorktrees.has(entryPath)) continue;
+
+    try {
+      rmSync(entryPath, { recursive: true, force: true });
+      console.log(`Cleaned up orphan workspace: ${entry}`);
+    } catch (err) {
+      console.error(`Failed to cleanup workspace ${entry}:`, err.message);
+    }
+  }
 }
 
 // REST API
@@ -154,10 +219,10 @@ app.patch('/api/tasks/:id/reject', (req, res) => {
   res.json({ ok: true });
 });
 
-app.patch('/api/tasks/:id/approve-max-review-blocker', (req, res) => {
+app.patch('/api/tasks/:id/approve-max-review-blocker', async (req, res) => {
   const task = store.getTask(req.params.id);
   if (!task) return res.status(404).json({ error: 'Task not found' });
-  if (!approveMaxReviewBlocker(task.id)) {
+  if (!await approveMaxReviewBlocker(task.id)) {
     return res.status(400).json({ error: 'Task is not blocked by maximum review cycles' });
   }
   res.json({ ok: true });
@@ -786,23 +851,7 @@ async function ensureAppStarted() {
   startupPromise = (async () => {
     store.restartRecovery();
 
-    const workspacesDir = getWorkspacesDir();
-    if (existsSync(workspacesDir)) {
-      const terminalStatuses = ['done', 'backlog', 'aborted', 'awaiting_human_review'];
-      let entries;
-      try { entries = readdirSync(workspacesDir); } catch { entries = []; }
-      for (const entry of entries) {
-        const task = store.getTask(entry);
-        if (!task || terminalStatuses.includes(task.status)) {
-          try {
-            rmSync(join(workspacesDir, entry), { recursive: true, force: true });
-            console.log(`Cleaned up orphan workspace: ${entry}`);
-          } catch (err) {
-            console.error(`Failed to cleanup workspace ${entry}:`, err.message);
-          }
-        }
-      }
-    }
+    await cleanupOrphanTaskWorktrees();
 
     const imported = await import('./orchestrator.js');
     orchestrator = imported.default;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -112,6 +112,7 @@ export async function cleanupOrphanTaskWorktrees() {
   const repoPaths = [...new Set(tasks.map(task => task?.repoPath).filter(Boolean))];
   const registeredWorktrees = new Set();
 
+  let repoInspectionFailed = false;
   for (const repoPath of repoPaths) {
     try {
       const output = await simpleGit(repoPath).raw(['worktree', 'list', '--porcelain']);
@@ -119,9 +120,12 @@ export async function cleanupOrphanTaskWorktrees() {
         registeredWorktrees.add(entry.path);
       }
     } catch {
-      // Ignore repo inspection failures and avoid deleting paths conservatively.
+      repoInspectionFailed = true;
+      console.warn(`Skipping orphan cleanup: failed to inspect worktrees for ${repoPath}`);
     }
   }
+
+  if (repoInspectionFailed) return;
 
   for (const entry of entries) {
     if (!entry.startsWith('T-')) continue;

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -8,6 +8,7 @@ import { resolve, dirname as pathDirname, join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { simpleGit } from 'simple-git';
+import { parseWorktreeList } from './worktree.js';
 import config, { loadSettings, saveSettings, validateSettings, getWorkspacesDir, getRuntimeStatePaths } from './config.js';
 import { getGithubCapabilities } from './capabilities.js';
 import store from './store.js';
@@ -86,21 +87,6 @@ function extendMaxReviewBlocker(taskId) {
   return true;
 }
 
-function parseWorktreeList(rawOutput) {
-  const worktrees = new Set();
-  if (typeof rawOutput !== 'string' || !rawOutput.trim()) return worktrees;
-
-  for (const block of rawOutput.trim().split('\n\n')) {
-    for (const line of block.split('\n')) {
-      if (line.startsWith('worktree ')) {
-        worktrees.add(line.slice('worktree '.length).trim());
-      }
-    }
-  }
-
-  return worktrees;
-}
-
 export async function cleanupOrphanTaskWorktrees() {
   const workspacesDir = getWorkspacesDir();
   if (!existsSync(workspacesDir)) return;
@@ -129,8 +115,8 @@ export async function cleanupOrphanTaskWorktrees() {
   for (const repoPath of repoPaths) {
     try {
       const output = await simpleGit(repoPath).raw(['worktree', 'list', '--porcelain']);
-      for (const worktreePath of parseWorktreeList(output)) {
-        registeredWorktrees.add(worktreePath);
+      for (const entry of parseWorktreeList(output)) {
+        registeredWorktrees.add(entry.path);
       }
     } catch {
       // Ignore repo inspection failures and avoid deleting paths conservatively.
@@ -144,8 +130,20 @@ export async function cleanupOrphanTaskWorktrees() {
     if (referencedWorkspacePaths.has(entryPath)) continue;
     if (registeredWorktrees.has(entryPath)) continue;
 
+    let removedByGit = false;
+    for (const repoPath of repoPaths) {
+      try {
+        await simpleGit(repoPath).raw(['worktree', 'remove', '--force', entryPath]);
+        removedByGit = true;
+        break;
+      } catch {
+        // Not a worktree for this repo or repo inaccessible.
+      }
+    }
     try {
-      rmSync(entryPath, { recursive: true, force: true });
+      if (!removedByGit || existsSync(entryPath)) {
+        rmSync(entryPath, { recursive: true, force: true });
+      }
       console.log(`Cleaned up orphan workspace: ${entry}`);
     } catch (err) {
       console.error(`Failed to cleanup workspace ${entry}:`, err.message);

--- a/server/src/index.js
+++ b/server/src/index.js
@@ -130,20 +130,8 @@ export async function cleanupOrphanTaskWorktrees() {
     if (referencedWorkspacePaths.has(entryPath)) continue;
     if (registeredWorktrees.has(entryPath)) continue;
 
-    let removedByGit = false;
-    for (const repoPath of repoPaths) {
-      try {
-        await simpleGit(repoPath).raw(['worktree', 'remove', '--force', entryPath]);
-        removedByGit = true;
-        break;
-      } catch {
-        // Not a worktree for this repo or repo inaccessible.
-      }
-    }
     try {
-      if (!removedByGit || existsSync(entryPath)) {
-        rmSync(entryPath, { recursive: true, force: true });
-      }
+      rmSync(entryPath, { recursive: true, force: true });
       console.log(`Cleaned up orphan workspace: ${entry}`);
     } catch (err) {
       console.error(`Failed to cleanup workspace ${entry}:`, err.message);
@@ -564,7 +552,7 @@ wss.on('connection', (ws) => {
     ts: Date.now(),
   }));
 
-  ws.on('message', (raw) => {
+  ws.on('message', async (raw) => {
     let msg;
     try { msg = JSON.parse(raw); } catch { return; }
 
@@ -682,7 +670,7 @@ wss.on('connection', (ws) => {
       }
       case 'APPROVE_MAX_REVIEW_BLOCKER': {
         const { taskId } = msg.payload || {};
-        if (taskId) approveMaxReviewBlocker(taskId);
+        if (taskId) await approveMaxReviewBlocker(taskId);
         break;
       }
       case 'EXTEND_MAX_REVIEW_BLOCKER': {

--- a/server/src/index.test.js
+++ b/server/src/index.test.js
@@ -1,10 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
-import { existsSync, mkdirSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join } from 'node:path';
 
 const mockStore = {
   getTask: vi.fn(),
+  getAllTasks: vi.fn(() => []),
   updateTask: vi.fn(),
   appendLog: vi.fn(),
   restartRecovery: vi.fn(),
@@ -15,6 +13,19 @@ const mockBus = {
   on: vi.fn(),
 };
 
+const removeTaskWorktree = vi.fn(async () => true);
+const orchestratorStart = vi.fn();
+
+const existsSync = vi.fn();
+const readdirSync = vi.fn();
+const rmSync = vi.fn();
+const statSync = vi.fn();
+const mkdirSync = vi.fn();
+const writeFileSync = vi.fn();
+const readFileSync = vi.fn(() => '');
+const chmodSync = vi.fn();
+const repoRaw = vi.fn();
+
 vi.mock('./store.js', () => ({
   default: mockStore,
 }));
@@ -23,7 +34,70 @@ vi.mock('./events.js', () => ({
   default: mockBus,
 }));
 
-const { approveMaxReviewBlocker } = await import('./index.js');
+vi.mock('./config.js', () => ({
+  default: { PORT: 3001 },
+  loadSettings: vi.fn(() => ({
+    workspaceRoot: '/tmp/workspaces',
+    agents: {
+      planners: { max: 1, cli: 'codex', model: '' },
+      implementors: { max: 1, cli: 'codex', model: '' },
+      reviewers: { max: 1, cli: 'codex', model: '' },
+    },
+  })),
+  saveSettings: vi.fn(),
+  validateSettings: vi.fn(() => []),
+  getWorkspacesDir: vi.fn(() => '/tmp/workspaces'),
+  getRuntimeStatePaths: vi.fn(() => ({
+    clientDistDir: '/tmp/client-dist',
+    rootDir: '/tmp/root',
+    dataDir: '/tmp/data',
+    bridgesDir: '/tmp/bridges',
+    envFile: '/tmp/.env.local',
+    packaged: false,
+  })),
+}));
+
+vi.mock('./agents.js', () => ({
+  default: {
+    get: vi.fn(),
+    getAllStatus: vi.fn(() => []),
+  },
+}));
+
+vi.mock('./orchestrator.js', () => ({
+  default: {
+    start: orchestratorStart,
+    deleteTask: vi.fn(),
+  },
+  removeTaskWorktree,
+}));
+
+vi.mock('simple-git', () => ({
+  simpleGit: vi.fn((cwd) => {
+    if (cwd === '/repo') return { raw: repoRaw };
+    return { raw: vi.fn() };
+  }),
+}));
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs');
+  return {
+    ...actual,
+    existsSync,
+    readdirSync,
+    rmSync,
+    statSync,
+    mkdirSync,
+    writeFileSync,
+    readFileSync,
+    chmodSync,
+  };
+});
+
+const {
+  approveMaxReviewBlocker,
+  cleanupOrphanTaskWorktrees,
+} = await import('./index.js');
 
 describe('approveMaxReviewBlocker', () => {
   beforeEach(() => {
@@ -32,25 +106,22 @@ describe('approveMaxReviewBlocker', () => {
     mockStore.appendLog.mockReset();
     mockStore.restartRecovery.mockReset();
     mockBus.emit.mockReset();
-    mockBus.on.mockClear();
+    removeTaskWorktree.mockReset();
   });
 
-  test('cleans up the workspace directory and clears workspacePath when approving to done', () => {
-    const workspacePath = join(tmpdir(), `bankan-approve-${Date.now()}`);
-    mkdirSync(workspacePath, { recursive: true });
+  test('removes the task worktree through the orchestrator cleanup path before approving to done', async () => {
     const task = {
       id: 'T-1',
       status: 'blocked',
       blockedReason: 'Reached maximum review cycles (3). Human input required.',
-      workspacePath,
+      workspacePath: '/tmp/workspaces/T-1',
+      repoPath: '/repo',
     };
     mockStore.getTask.mockReturnValue(task);
 
-    expect(existsSync(workspacePath)).toBe(true);
+    expect(await approveMaxReviewBlocker('T-1')).toBe(true);
 
-    expect(approveMaxReviewBlocker('T-1')).toBe(true);
-
-    expect(existsSync(workspacePath)).toBe(false);
+    expect(removeTaskWorktree).toHaveBeenCalledWith(task);
     expect(mockStore.updateTask).toHaveBeenCalledWith('T-1', expect.objectContaining({
       status: 'done',
       workspacePath: null,
@@ -60,6 +131,35 @@ describe('approveMaxReviewBlocker', () => {
       'Human override: approved task to done after max review cycles.'
     );
     expect(mockBus.emit).toHaveBeenCalledWith('max-review-blocker:approved', { taskId: 'T-1' });
-    rmSync(workspacePath, { recursive: true, force: true });
+  });
+});
+
+describe('cleanupOrphanTaskWorktrees', () => {
+  beforeEach(() => {
+    mockStore.getTask.mockReset();
+    mockStore.getAllTasks.mockReset();
+    existsSync.mockReset();
+    readdirSync.mockReset();
+    rmSync.mockReset();
+    repoRaw.mockReset();
+  });
+
+  test('preserves active and registered task worktrees while removing orphan task directories', async () => {
+    existsSync.mockReturnValue(true);
+    readdirSync.mockReturnValue(['T-active', 'T-registered', 'T-orphan', 'notes']);
+    mockStore.getTask.mockImplementation((id) => {
+      if (id === 'T-active') return { id, status: 'implementing', workspacePath: '/tmp/workspaces/T-active', repoPath: '/repo' };
+      return null;
+    });
+    mockStore.getAllTasks.mockReturnValue([
+      { id: 'T-active', status: 'implementing', workspacePath: '/tmp/workspaces/T-active', repoPath: '/repo' },
+      { id: 'T-done', status: 'done', workspacePath: '/tmp/workspaces/T-registered', repoPath: '/repo' },
+    ]);
+    repoRaw.mockResolvedValue('worktree /repo\nbranch refs/heads/main\n\nworktree /tmp/workspaces/T-registered\nbranch refs/heads/feature/t-registered\n\n');
+
+    await cleanupOrphanTaskWorktrees();
+
+    expect(rmSync).toHaveBeenCalledTimes(1);
+    expect(rmSync).toHaveBeenCalledWith('/tmp/workspaces/T-orphan', expect.objectContaining({ recursive: true, force: true }));
   });
 });

--- a/server/src/index.test.js
+++ b/server/src/index.test.js
@@ -124,7 +124,6 @@ describe('approveMaxReviewBlocker', () => {
     expect(removeTaskWorktree).toHaveBeenCalledWith(task);
     expect(mockStore.updateTask).toHaveBeenCalledWith('T-1', expect.objectContaining({
       status: 'done',
-      workspacePath: null,
     }));
     expect(mockStore.appendLog).toHaveBeenCalledWith(
       'T-1',

--- a/server/src/orchestrator.delete.test.js
+++ b/server/src/orchestrator.delete.test.js
@@ -4,6 +4,8 @@ const getTask = vi.fn();
 const deleteTaskStore = vi.fn();
 const removePlan = vi.fn();
 const appendLog = vi.fn();
+const updateTask = vi.fn();
+const repoRaw = vi.fn();
 
 vi.mock('./store.js', () => ({
   default: {
@@ -11,7 +13,7 @@ vi.mock('./store.js', () => ({
     deleteTask: deleteTaskStore,
     removePlan,
     appendLog,
-    updateTask: vi.fn(),
+    updateTask,
     restartRecovery: vi.fn(),
     getAllTasks: vi.fn(() => []),
   },
@@ -48,7 +50,29 @@ vi.mock('./config.js', () => ({
 }));
 
 vi.mock('simple-git', () => ({
-  simpleGit: vi.fn(() => ({})),
+  simpleGit: vi.fn((cwd) => {
+    if (cwd === '/repo') {
+      return { raw: repoRaw };
+    }
+    return {};
+  }),
+}));
+
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual('node:fs');
+  return {
+    ...actual,
+    existsSync: vi.fn(() => true),
+    mkdirSync: vi.fn(),
+    readFileSync: vi.fn(() => ''),
+    readdirSync: vi.fn(() => []),
+    unlinkSync: vi.fn(),
+  };
+});
+
+const rm = vi.fn();
+vi.mock('node:fs/promises', () => ({
+  rm,
 }));
 
 const orchestrator = (await import('./orchestrator.js')).default;
@@ -59,6 +83,9 @@ describe('deleteTask', () => {
     getTask.mockReset();
     deleteTaskStore.mockReset();
     removePlan.mockReset();
+    updateTask.mockReset();
+    repoRaw.mockReset();
+    rm.mockReset();
   });
 
   test('succeeds for a task with status done', async () => {
@@ -91,5 +118,22 @@ describe('deleteTask', () => {
     getTask.mockReturnValue(undefined);
     const result = await deleteTask('T-999');
     expect(result).toBe(false);
+  });
+
+  test('removes a task worktree before deleting terminal tasks', async () => {
+    getTask.mockReturnValue({
+      id: 'T-4',
+      status: 'done',
+      workspacePath: '/tmp/workspaces/T-4',
+      repoPath: '/repo',
+    });
+
+    const result = await deleteTask('T-4');
+
+    expect(result).toBe(true);
+    expect(repoRaw).toHaveBeenCalledWith(['worktree', 'remove', '--force', '/tmp/workspaces/T-4']);
+    expect(updateTask).toHaveBeenCalledWith('T-4', { workspacePath: null });
+    expect(deleteTaskStore).toHaveBeenCalledWith('T-4');
+    expect(rm).not.toHaveBeenCalled();
   });
 });

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -646,7 +646,13 @@ async function configureTaskWorktree(workspacePath) {
   return worktreeGit;
 }
 
+const PROTECTED_BRANCHES = ['main', 'master', 'develop'];
+
 export async function prepareTaskWorktree(task) {
+  if (!task.branch || PROTECTED_BRANCHES.includes(task.branch)) {
+    throw new Error(`Invalid task branch "${task.branch || ''}" — cannot use a protected or empty branch name for worktree setup`);
+  }
+
   const settings = loadSettings();
   const workspaceRoot = getWorkspacesDir(settings);
   const workspacePath = getTaskWorktreePath(task, settings);
@@ -676,11 +682,6 @@ export async function prepareTaskWorktree(task) {
     await rm(workspacePath, { recursive: true, force: true, maxRetries: 3, retryDelay: 500 });
   }
 
-  const PROTECTED_BRANCHES = ['main', 'master', 'develop'];
-  if (!task.branch || PROTECTED_BRANCHES.includes(task.branch)) {
-    throw new Error(`Invalid task branch "${task.branch || ''}" — cannot use a protected or empty branch name for worktree setup`);
-  }
-
   const branches = await repoGit.branchLocal();
   if (branches.all.includes(task.branch)) {
     await repoGit.deleteLocalBranch(task.branch, true);
@@ -694,24 +695,29 @@ export async function prepareTaskWorktree(task) {
 export async function removeTaskWorktree(task) {
   if (!task?.workspacePath) return;
 
-  try {
-    if (task.repoPath) {
-      await simpleGit(task.repoPath).raw(['worktree', 'remove', '--force', task.workspacePath]);
-    } else {
-      throw new Error('Task repoPath is missing');
-    }
-  } catch (err) {
+  let removed = false;
+
+  if (task.repoPath) {
     try {
-      await rm(task.workspacePath, { recursive: true, force: true, maxRetries: 3, retryDelay: 500 });
-    } catch (rmErr) {
-      console.warn(`Could not remove workspace ${task.workspacePath}: ${rmErr.message}`);
-    }
-    if (err?.message && err.message !== 'Task repoPath is missing') {
+      await simpleGit(task.repoPath).raw(['worktree', 'remove', '--force', task.workspacePath]);
+      removed = true;
+    } catch (err) {
       console.warn(`Git worktree removal failed for ${task.workspacePath}: ${err.message}`);
     }
   }
 
-  store.updateTask(task.id, { workspacePath: null });
+  if (!removed) {
+    try {
+      await rm(task.workspacePath, { recursive: true, force: true, maxRetries: 3, retryDelay: 500 });
+      removed = true;
+    } catch (rmErr) {
+      console.warn(`Could not remove workspace ${task.workspacePath}: ${rmErr.message}`);
+    }
+  }
+
+  if (removed) {
+    store.updateTask(task.id, { workspacePath: null });
+  }
 }
 
 function buildManualPrGuidance(task, capabilities = getGithubCapabilities()) {
@@ -811,11 +817,13 @@ export async function startPlanning(task) {
   const cmd = buildAgentCommand(planner.cli, prompt, 'plan', planner.model);
   const plannerCwd = task.repoPath;
   if (!plannerCwd || !existsSync(plannerCwd)) {
+    const reason = `Task repo path is not a valid local directory: ${plannerCwd || '(empty)'}`;
     store.updateTask(task.id, {
       status: 'blocked',
-      blockedReason: `Task repo path is not a valid local directory: ${plannerCwd || '(empty)'}`,
+      blockedReason: reason,
       assignedTo: null,
     });
+    bus.emit('task:blocked', { taskId: task.id, reason });
     retireAgentSession(planner, { taskId: task.id, outcome: 'blocked' });
     return false;
   }

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -1163,7 +1163,6 @@ async function abortTask(taskId) {
   store.updateTask(taskId, {
     status: 'aborted',
     assignedTo: null,
-    workspacePath: null,
     blockedReason: null,
     reviewFeedback: null,
     previousStatus: null,
@@ -1189,7 +1188,6 @@ async function resetTask(taskId) {
   store.updateTask(taskId, {
     status: 'backlog',
     assignedTo: null,
-    workspacePath: null,
     branch: null,
     plan: null,
     review: null,

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -652,6 +652,9 @@ export async function prepareTaskWorktree(task) {
   if (!task.branch || PROTECTED_BRANCHES.includes(task.branch)) {
     throw new Error(`Invalid task branch "${task.branch || ''}" — cannot use a protected or empty branch name for worktree setup`);
   }
+  if (!task.repoPath || !existsSync(task.repoPath)) {
+    throw new Error(`Invalid task repo path: ${task.repoPath || '(empty)'}`);
+  }
 
   const settings = loadSettings();
   const workspaceRoot = getWorkspacesDir(settings);
@@ -681,6 +684,11 @@ export async function prepareTaskWorktree(task) {
   if (existsSync(workspacePath)) {
     await rm(workspacePath, { recursive: true, force: true, maxRetries: 3, retryDelay: 500 });
   }
+
+  // Prune stale worktree registrations (e.g., after rm deleted the directory
+  // but git worktree remove failed, leaving a dangling registration that
+  // would block deleteLocalBranch).
+  await repoGit.raw(['worktree', 'prune']);
 
   const branches = await repoGit.branchLocal();
   if (branches.all.includes(task.branch)) {

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -673,8 +673,8 @@ export async function prepareTaskWorktree(task) {
   if (registeredWorktree) {
     try {
       await repoGit.raw(['worktree', 'remove', '--force', workspacePath]);
-    } catch {
-      // Fall through to filesystem cleanup below.
+    } catch (err) {
+      console.warn(`Git worktree remove failed for ${workspacePath}, falling back to rm: ${err.message}`);
     }
   }
 

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -3,6 +3,7 @@ import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { simpleGit } from 'simple-git';
+import { parseWorktreeList } from './worktree.js';
 import { loadSettings, getWorkspacesDir } from './config.js';
 import { getGithubCapabilities, isManualPullRequestRequired } from './capabilities.js';
 import store from './store.js';
@@ -637,21 +638,6 @@ function getTaskWorktreePath(task, settings = loadSettings()) {
   return join(getWorkspacesDir(settings), task.id);
 }
 
-function parseWorktreeList(rawOutput) {
-  const worktrees = [];
-  if (typeof rawOutput !== 'string' || !rawOutput.trim()) return worktrees;
-
-  const blocks = rawOutput.trim().split('\n\n');
-  for (const block of blocks) {
-    const entry = {};
-    for (const line of block.split('\n')) {
-      if (line.startsWith('worktree ')) entry.path = line.slice('worktree '.length).trim();
-      if (line.startsWith('branch ')) entry.branchRef = line.slice('branch '.length).trim();
-    }
-    if (entry.path) worktrees.push(entry);
-  }
-  return worktrees;
-}
 
 async function configureTaskWorktree(workspacePath) {
   const worktreeGit = simpleGit(workspacePath);
@@ -688,6 +674,11 @@ export async function prepareTaskWorktree(task) {
 
   if (existsSync(workspacePath)) {
     await rm(workspacePath, { recursive: true, force: true, maxRetries: 3, retryDelay: 500 });
+  }
+
+  const PROTECTED_BRANCHES = ['main', 'master', 'develop'];
+  if (!task.branch || PROTECTED_BRANCHES.includes(task.branch)) {
+    throw new Error(`Invalid task branch "${task.branch || ''}" — cannot use a protected or empty branch name for worktree setup`);
   }
 
   const branches = await repoGit.branchLocal();
@@ -819,6 +810,15 @@ export async function startPlanning(task) {
   const prompt = buildPlannerPrompt(task);
   const cmd = buildAgentCommand(planner.cli, prompt, 'plan', planner.model);
   const plannerCwd = task.repoPath;
+  if (!plannerCwd || !existsSync(plannerCwd)) {
+    store.updateTask(task.id, {
+      status: 'blocked',
+      blockedReason: `Task repo path is not a valid local directory: ${plannerCwd || '(empty)'}`,
+      assignedTo: null,
+    });
+    retireAgentSession(planner, { taskId: task.id, outcome: 'blocked' });
+    return false;
+  }
   const ok = planner.spawn(plannerCwd, cmd);
   if (!ok) {
     store.updateTask(task.id, {

--- a/server/src/orchestrator.js
+++ b/server/src/orchestrator.js
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, readFileSync, readdirSync, unlinkSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, unlinkSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
@@ -529,11 +529,11 @@ function getAuthBlockedReason(buffer, cli = '') {
   return null;
 }
 
-function buildPlannerPrompt(task) {
+export function buildPlannerPrompt(task) {
   const promptBody = getPromptBody('planning');
   let prompt = `You are a senior software architect. A task has been assigned to you.
 Repository: ${task.repoPath}
-Workspace: ${task.workspacePath}
+Workspace: planning runs in the repository checkout until implementation creates a task worktree.
 
 TASK ID: ${task.id}
 TITLE: ${task.title}
@@ -633,89 +633,94 @@ SUMMARY: 2-3 concrete sentences summarising the review, including changed files 
 
 // --- Workspace Helpers ---
 
-async function setupWorkspace(task) {
-  const settings = loadSettings();
-  const workspaceRoot = join(getWorkspacesDir(settings), task.id);
-  const existingWorkspace = task.workspacePath;
+function getTaskWorktreePath(task, settings = loadSettings()) {
+  return join(getWorkspacesDir(settings), task.id);
+}
 
-  if (existingWorkspace && existsSync(existingWorkspace)) {
-    return existingWorkspace;
+function parseWorktreeList(rawOutput) {
+  const worktrees = [];
+  if (typeof rawOutput !== 'string' || !rawOutput.trim()) return worktrees;
+
+  const blocks = rawOutput.trim().split('\n\n');
+  for (const block of blocks) {
+    const entry = {};
+    for (const line of block.split('\n')) {
+      if (line.startsWith('worktree ')) entry.path = line.slice('worktree '.length).trim();
+      if (line.startsWith('branch ')) entry.branchRef = line.slice('branch '.length).trim();
+    }
+    if (entry.path) worktrees.push(entry);
+  }
+  return worktrees;
+}
+
+async function configureTaskWorktree(workspacePath) {
+  const worktreeGit = simpleGit(workspacePath);
+  await worktreeGit.addConfig('user.email', 'ai-factory@local');
+  await worktreeGit.addConfig('user.name', 'AI Factory');
+  return worktreeGit;
+}
+
+export async function prepareTaskWorktree(task) {
+  const settings = loadSettings();
+  const workspaceRoot = getWorkspacesDir(settings);
+  const workspacePath = getTaskWorktreePath(task, settings);
+  const repoGit = simpleGit(task.repoPath);
+
+  mkdirSync(workspaceRoot, { recursive: true });
+  await repoGit.fetch('origin', 'main');
+
+  const worktrees = parseWorktreeList(await repoGit.raw(['worktree', 'list', '--porcelain']));
+  const registeredWorktree = worktrees.find(entry => entry.path === workspacePath);
+  const expectedBranchRef = `refs/heads/${task.branch}`;
+
+  if (registeredWorktree?.branchRef === expectedBranchRef && existsSync(workspacePath)) {
+    await configureTaskWorktree(workspacePath);
+    return workspacePath;
   }
 
-  if (existsSync(workspaceRoot)) {
+  if (registeredWorktree) {
     try {
-      const entries = readdirSync(workspaceRoot);
-      if (entries.length === 0) {
-        await rm(workspaceRoot, { recursive: true, force: true });
-      } else if (existsSync(join(workspaceRoot, '.git'))) {
-        try {
-          const wsGit = simpleGit(workspaceRoot);
-          const remotes = await wsGit.getRemotes(true);
-          const origin = remotes.find(remote => remote.name === 'origin');
-          const fetchUrl = origin?.refs?.fetch || '';
-          const pushUrl = origin?.refs?.push || '';
-
-          if ([fetchUrl, pushUrl].includes(task.repoPath)) {
-            await wsGit.addConfig('user.email', 'ai-factory@local');
-            await wsGit.addConfig('user.name', 'AI Factory');
-            try { await wsGit.fetch('origin'); } catch { /* ignore */ }
-            return workspaceRoot;
-          }
-        } catch {
-          // Fall through to remove and recreate the workspace.
-        }
-
-        await rm(workspaceRoot, { recursive: true, force: true });
-      } else {
-        await rm(workspaceRoot, { recursive: true, force: true });
-      }
+      await repoGit.raw(['worktree', 'remove', '--force', workspacePath]);
     } catch {
-      await rm(workspaceRoot, { recursive: true, force: true });
+      // Fall through to filesystem cleanup below.
     }
   }
 
-  mkdirSync(workspaceRoot, { recursive: true });
-
-  await simpleGit().clone(task.repoPath, workspaceRoot);
-
-  const wsGit = simpleGit(workspaceRoot);
-  await wsGit.addConfig('user.email', 'ai-factory@local');
-  await wsGit.addConfig('user.name', 'AI Factory');
-  await wsGit.pull('origin', 'main');
-
-  return workspaceRoot;
-}
-
-async function prepareWorkspaceBranch(task) {
-  const workspacePath = await setupWorkspace(task);
-  const git = simpleGit(workspacePath);
-  const branches = await git.branchLocal();
-
-  if (!branches.current) {
-    await git.checkout('main');
+  if (existsSync(workspacePath)) {
+    await rm(workspacePath, { recursive: true, force: true, maxRetries: 3, retryDelay: 500 });
   }
 
-  if (!branches.all.includes(task.branch)) {
-    await git.checkout('main');
-    await git.pull('origin', 'main');
-    try { await git.push('origin', `:${task.branch}`); } catch { /* ignore */ }
-    await git.checkoutLocalBranch(task.branch);
-  } else {
-    await git.checkout(task.branch);
+  const branches = await repoGit.branchLocal();
+  if (branches.all.includes(task.branch)) {
+    await repoGit.deleteLocalBranch(task.branch, true);
   }
 
+  await repoGit.raw(['worktree', 'add', '-b', task.branch, workspacePath, 'origin/main']);
+  await configureTaskWorktree(workspacePath);
   return workspacePath;
 }
 
-async function cleanupWorkspace(task) {
-  if (task.workspacePath) {
+export async function removeTaskWorktree(task) {
+  if (!task?.workspacePath) return;
+
+  try {
+    if (task.repoPath) {
+      await simpleGit(task.repoPath).raw(['worktree', 'remove', '--force', task.workspacePath]);
+    } else {
+      throw new Error('Task repoPath is missing');
+    }
+  } catch (err) {
     try {
       await rm(task.workspacePath, { recursive: true, force: true, maxRetries: 3, retryDelay: 500 });
-    } catch (err) {
-      console.warn(`Could not remove workspace ${task.workspacePath}: ${err.message}`);
+    } catch (rmErr) {
+      console.warn(`Could not remove workspace ${task.workspacePath}: ${rmErr.message}`);
     }
-    store.updateTask(task.id, { workspacePath: null });
+    if (err?.message && err.message !== 'Task repoPath is missing') {
+      console.warn(`Git worktree removal failed for ${task.workspacePath}: ${err.message}`);
+    }
   }
+
+  store.updateTask(task.id, { workspacePath: null });
 }
 
 function buildManualPrGuidance(task, capabilities = getGithubCapabilities()) {
@@ -779,7 +784,7 @@ function retireAgentSession(agent, {
 
 // --- Stage Transitions ---
 
-async function startPlanning(task) {
+export async function startPlanning(task) {
   if (isStageDisabled('planning')) {
     const planText = buildSyntheticPlan(task);
     const branch = extractSingleLine(planText, 'BRANCH:') || generateBranchName(task);
@@ -801,37 +806,19 @@ async function startPlanning(task) {
   const planner = agentManager.getAvailablePlanner();
   if (!planner) return false;
 
-  store.updateTask(task.id, { status: 'workspace_setup', assignedTo: planner.id, blockedReason: null });
   planner.currentTask = task.id;
-  planner.taskLabel = `Preparing: ${task.title}`;
-  planner.status = 'active';
-  bus.emit('agent:updated', planner.getStatus());
-
-  let workspacePath;
-  try {
-    workspacePath = await setupWorkspace(task);
-  } catch (err) {
-    store.updateTask(task.id, {
-      status: 'blocked',
-      blockedReason: `Workspace setup failed: ${err.message}`,
-      assignedTo: null,
-    });
-    retireAgentSession(planner, { taskId: task.id, outcome: 'blocked' });
-    bus.emit('task:blocked', { taskId: task.id, reason: 'Workspace setup failed' });
-    return false;
-  }
-
   store.updateTask(task.id, {
     status: 'planning',
     assignedTo: planner.id,
-    workspacePath,
     blockedReason: null,
   });
   planner.taskLabel = `Planning: ${task.title}`;
+  planner.status = 'active';
+  bus.emit('agent:updated', planner.getStatus());
 
-  const prompt = buildPlannerPrompt({ ...task, workspacePath });
+  const prompt = buildPlannerPrompt(task);
   const cmd = buildAgentCommand(planner.cli, prompt, 'plan', planner.model);
-  const plannerCwd = workspacePath;
+  const plannerCwd = task.repoPath;
   const ok = planner.spawn(plannerCwd, cmd);
   if (!ok) {
     store.updateTask(task.id, {
@@ -919,7 +906,7 @@ async function startImplementation(task) {
 
   let workspacePath;
   try {
-    workspacePath = await prepareWorkspaceBranch(task);
+    workspacePath = await prepareTaskWorktree(task);
   } catch (err) {
     console.error(`Workspace setup failed for ${task.id}:`, err.message);
     store.updateTask(task.id, {
@@ -1123,7 +1110,7 @@ export async function createPR(taskId) {
     });
     bus.emit('pr:created', { taskId, prUrl });
 
-    await cleanupWorkspace(store.getTask(taskId));
+    await removeTaskWorktree(store.getTask(taskId));
     store.updateTask(taskId, { status: 'done', assignedTo: null });
   } catch (err) {
     if (isManualPrAutomationError(err)) {
@@ -1144,7 +1131,7 @@ async function completeManualPr(taskId) {
   const task = store.getTask(taskId);
   if (!task || task.status !== 'awaiting_manual_pr') return;
 
-  await cleanupWorkspace(task);
+  await removeTaskWorktree(task);
   store.updateTask(taskId, {
     status: 'done',
     assignedTo: null,
@@ -1163,7 +1150,7 @@ async function abortTask(taskId) {
     if (agent) retireAgentSession(agent, { taskId, outcome: 'aborted' });
   }
 
-  await cleanupWorkspace(task);
+  await removeTaskWorktree(task);
 
   store.updateTask(taskId, {
     status: 'aborted',
@@ -1188,7 +1175,7 @@ async function resetTask(taskId) {
     if (agent) retireAgentSession(agent, { taskId, outcome: 'reset' });
   }
 
-  await cleanupWorkspace(task);
+  await removeTaskWorktree(task);
   store.removePlan(taskId);
 
   store.updateTask(taskId, {
@@ -1222,7 +1209,7 @@ async function deleteTask(taskId) {
   if (!task || !['done', 'aborted'].includes(task.status)) return false;
 
   if (task.workspacePath) {
-    await cleanupWorkspace(task);
+    await removeTaskWorktree(task);
   }
 
   store.removePlan(taskId);

--- a/server/src/orchestrator.pr.test.js
+++ b/server/src/orchestrator.pr.test.js
@@ -24,6 +24,7 @@ const fetchMock = vi.fn();
 const checkoutMock = vi.fn();
 const rebaseMock = vi.fn();
 const rawMock = vi.fn();
+const repoRawMock = vi.fn();
 const existsSyncMock = vi.fn();
 const execFileSyncMock = vi.fn();
 
@@ -66,12 +67,17 @@ vi.mock('./config.js', () => ({
 }));
 
 vi.mock('simple-git', () => ({
-  simpleGit: vi.fn(() => ({
-    fetch: fetchMock,
-    checkout: checkoutMock,
-    rebase: rebaseMock,
-    raw: rawMock,
-  })),
+  simpleGit: vi.fn((cwd) => {
+    if (cwd === '/repo') {
+      return { raw: repoRawMock };
+    }
+    return {
+      fetch: fetchMock,
+      checkout: checkoutMock,
+      rebase: rebaseMock,
+      raw: rawMock,
+    };
+  }),
 }));
 
 vi.mock('node:fs', async () => {
@@ -118,6 +124,7 @@ describe('createPR', () => {
     checkoutMock.mockReset();
     rebaseMock.mockReset();
     rawMock.mockReset();
+    repoRawMock.mockReset();
     existsSyncMock.mockReset();
     execFileSyncMock.mockReset();
 
@@ -173,5 +180,24 @@ describe('createPR', () => {
     expect(emit).not.toHaveBeenCalledWith('task:manual-pr-required', expect.anything());
 
     consoleError.mockRestore();
+  });
+
+  test('removes the task worktree after PR creation succeeds', async () => {
+    execFileSyncMock.mockImplementation((cmd) => {
+      if (cmd === 'gh') return 'https://github.com/example/repo/pull/42';
+      return '';
+    });
+
+    const { createPR } = await import('./orchestrator.js');
+
+    await createPR('T-42');
+
+    expect(rawMock).toHaveBeenCalledWith(['push', '--force-with-lease', 'origin', 'feature/t-42-manual-pr']);
+    expect(repoRawMock).toHaveBeenCalledWith(['worktree', 'remove', '--force', '/tmp/workspaces/T-42']);
+    expect(updateTask).toHaveBeenCalledWith('T-42', expect.objectContaining({
+      prUrl: 'https://github.com/example/repo/pull/42',
+    }));
+    expect(updateTask).toHaveBeenCalledWith('T-42', { workspacePath: null });
+    expect(updateTask).toHaveBeenCalledWith('T-42', expect.objectContaining({ status: 'done' }));
   });
 });

--- a/server/src/orchestrator.test.js
+++ b/server/src/orchestrator.test.js
@@ -578,6 +578,10 @@ describe('worktree lifecycle helpers', () => {
     };
     const simpleGitFactory = vi.fn();
 
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual('node:fs');
+      return { ...actual, existsSync: vi.fn(() => true) };
+    });
     vi.doMock('./store.js', () => ({
       default: {
         updateTask,

--- a/server/src/orchestrator.test.js
+++ b/server/src/orchestrator.test.js
@@ -725,7 +725,7 @@ describe('worktree lifecycle helpers', () => {
       const actual = await vi.importActual('node:fs');
       return {
         ...actual,
-        existsSync: vi.fn((path) => path === '/tmp/worktrees'),
+        existsSync: vi.fn((path) => path === '/tmp/worktrees' || path === '/repo/main-checkout'),
         mkdirSync: vi.fn(),
         readFileSync: vi.fn(() => ''),
         readdirSync: vi.fn(() => []),
@@ -773,7 +773,7 @@ describe('worktree lifecycle helpers', () => {
       if (cwd === '/tmp/worktrees/T-103') return worktreeGit;
       throw new Error(`unexpected cwd ${cwd}`);
     });
-    const existsSync = vi.fn((path) => path === '/tmp/worktrees' || path === '/tmp/worktrees/T-103');
+    const existsSync = vi.fn((path) => path === '/tmp/worktrees' || path === '/tmp/worktrees/T-103' || path === '/repo/main-checkout');
     const rm = vi.fn();
 
     vi.doMock('./store.js', () => ({

--- a/server/src/orchestrator.test.js
+++ b/server/src/orchestrator.test.js
@@ -752,7 +752,7 @@ describe('worktree lifecycle helpers', () => {
     expect(rm).not.toHaveBeenCalled();
   });
 
-  test('prepareTaskWorktree reuses a registered worktree and recreates stale task directories', async () => {
+  test('prepareTaskWorktree tears down and recreates worktree when registered branch does not match', async () => {
     const repoGit = {
       fetch: vi.fn(),
       branchLocal: vi.fn(() => ({ all: ['main', 'feature/t-103-reuse'] })),

--- a/server/src/orchestrator.test.js
+++ b/server/src/orchestrator.test.js
@@ -1,7 +1,8 @@
-import { describe, expect, test, vi } from 'vitest';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import {
   buildAgentCommand,
+  buildPlannerPrompt,
   buildImplementorPrompt,
   cleanTerminalArtifacts,
   extractImplementationResult,
@@ -555,5 +556,305 @@ RISKS:
     const cleaned = cleanTerminalArtifacts(dirty);
     expect(cleaned).toContain('BRANCH: feature/fix');
     expect(cleaned).not.toContain('❯');
+  });
+});
+
+describe('worktree lifecycle helpers', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  test('planning uses task.repoPath directly and does not provision a task workspace first', async () => {
+    const updateTask = vi.fn();
+    const emit = vi.fn();
+    const spawn = vi.fn(() => true);
+    const planner = {
+      id: 'plan-1',
+      cli: 'codex',
+      model: '',
+      spawn,
+      getStatus: vi.fn(() => ({ id: 'plan-1', status: 'active' })),
+    };
+    const simpleGitFactory = vi.fn();
+
+    vi.doMock('./store.js', () => ({
+      default: {
+        updateTask,
+        appendLog: vi.fn(),
+        appendSession: vi.fn(),
+        getTask: vi.fn(),
+        savePlan: vi.fn(),
+      },
+    }));
+    vi.doMock('./events.js', () => ({
+      default: {
+        emit,
+        on: vi.fn(),
+      },
+    }));
+    vi.doMock('./agents.js', () => ({
+      default: {
+        getAvailablePlanner: vi.fn(() => planner),
+        getAvailableImplementor: vi.fn(),
+        getAvailableReviewer: vi.fn(),
+        getAllStatus: vi.fn(() => []),
+        agents: new Map(),
+        getAgentsByRole: vi.fn(() => []),
+        get: vi.fn(),
+        removeAgent: vi.fn(),
+        scaleUp: vi.fn(),
+        reconfigure: vi.fn(),
+      },
+    }));
+    vi.doMock('./config.js', () => ({
+      loadSettings: vi.fn(() => ({
+        maxReviewCycles: 3,
+        agents: {
+          planners: { max: 1, cli: 'codex', model: '' },
+          implementors: { max: 1, cli: 'codex', model: '' },
+          reviewers: { max: 1, cli: 'codex', model: '' },
+        },
+      })),
+      getWorkspacesDir: vi.fn(() => '/tmp/workspaces'),
+    }));
+    vi.doMock('simple-git', () => ({
+      simpleGit: simpleGitFactory,
+    }));
+    vi.doMock('./workflow.js', () => ({
+      isReviewResultPlaceholder: vi.fn(() => false),
+      isPlanPlaceholder: vi.fn(() => false),
+      isImplementationPlaceholder: vi.fn(() => false),
+      parseReviewResult: vi.fn(() => ({ verdict: 'PASS', criticalIssues: [], minorIssues: [] })),
+      resolveTaskMaxReviewCycles: vi.fn((task, fallback = 3) => task?.maxReviewCycles || fallback),
+      reviewShouldPass: vi.fn(() => true),
+    }));
+    vi.doMock('./sessionHistory.js', () => ({
+      createSessionEntry: vi.fn(() => ({ id: 'session-1' })),
+    }));
+
+    const { startPlanning } = await import('./orchestrator.js');
+    const task = {
+      id: 'T-101',
+      title: 'Plan in repo checkout',
+      description: 'Planning should not create a worktree',
+      priority: 'medium',
+      repoPath: '/repo/main-checkout',
+      workspacePath: null,
+    };
+
+    await startPlanning(task);
+
+    expect(updateTask).not.toHaveBeenCalledWith(task.id, expect.objectContaining({ status: 'workspace_setup' }));
+    expect(updateTask).toHaveBeenCalledWith(task.id, expect.objectContaining({
+      status: 'planning',
+      assignedTo: 'plan-1',
+      blockedReason: null,
+    }));
+    expect(spawn).toHaveBeenCalledWith(task.repoPath, expect.any(String));
+    expect(simpleGitFactory).not.toHaveBeenCalled();
+  });
+
+  test('prepareTaskWorktree creates a branch-backed worktree under the configured workspace root', async () => {
+    const repoGit = {
+      fetch: vi.fn(),
+      branchLocal: vi.fn(() => ({ all: ['main'] })),
+      raw: vi.fn(async (args) => {
+        if (args[0] === 'worktree' && args[1] === 'list') return '';
+        return '';
+      }),
+      deleteLocalBranch: vi.fn(),
+    };
+    const worktreeGit = {
+      addConfig: vi.fn(),
+      branchLocal: vi.fn(() => ({ current: 'feature/t-102-worktree' })),
+    };
+    const simpleGitFactory = vi.fn((cwd) => {
+      if (cwd === '/repo/main-checkout') return repoGit;
+      if (cwd === '/tmp/worktrees/T-102') return worktreeGit;
+      throw new Error(`unexpected cwd ${cwd}`);
+    });
+
+    vi.doMock('./store.js', () => ({
+      default: {
+        updateTask: vi.fn(),
+        appendLog: vi.fn(),
+        appendSession: vi.fn(),
+        getTask: vi.fn(),
+        savePlan: vi.fn(),
+      },
+    }));
+    vi.doMock('./events.js', () => ({ default: { emit: vi.fn(), on: vi.fn() } }));
+    vi.doMock('./agents.js', () => ({
+      default: {
+        getAvailablePlanner: vi.fn(),
+        getAvailableImplementor: vi.fn(),
+        getAvailableReviewer: vi.fn(),
+        getAllStatus: vi.fn(() => []),
+        agents: new Map(),
+        getAgentsByRole: vi.fn(() => []),
+        get: vi.fn(),
+        removeAgent: vi.fn(),
+        scaleUp: vi.fn(),
+        reconfigure: vi.fn(),
+      },
+    }));
+    vi.doMock('./config.js', () => ({
+      loadSettings: vi.fn(() => ({ workspaceRoot: '/tmp/worktrees', maxReviewCycles: 3, agents: {} })),
+      getWorkspacesDir: vi.fn(() => '/tmp/worktrees'),
+    }));
+    vi.doMock('simple-git', () => ({
+      simpleGit: simpleGitFactory,
+    }));
+    vi.doMock('./workflow.js', () => ({
+      isReviewResultPlaceholder: vi.fn(() => false),
+      isPlanPlaceholder: vi.fn(() => false),
+      isImplementationPlaceholder: vi.fn(() => false),
+      parseReviewResult: vi.fn(() => ({ verdict: 'PASS', criticalIssues: [], minorIssues: [] })),
+      resolveTaskMaxReviewCycles: vi.fn((task, fallback = 3) => task?.maxReviewCycles || fallback),
+      reviewShouldPass: vi.fn(() => true),
+    }));
+    vi.doMock('./sessionHistory.js', () => ({
+      createSessionEntry: vi.fn(() => ({ id: 'session-1' })),
+    }));
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual('node:fs');
+      return {
+        ...actual,
+        existsSync: vi.fn((path) => path === '/tmp/worktrees'),
+        mkdirSync: vi.fn(),
+        readFileSync: vi.fn(() => ''),
+        readdirSync: vi.fn(() => []),
+        unlinkSync: vi.fn(),
+      };
+    });
+    const rm = vi.fn();
+    vi.doMock('node:fs/promises', () => ({ rm }));
+
+    const { prepareTaskWorktree } = await import('./orchestrator.js');
+    const task = {
+      id: 'T-102',
+      repoPath: '/repo/main-checkout',
+      branch: 'feature/t-102-worktree',
+    };
+
+    const workspacePath = await prepareTaskWorktree(task);
+
+    expect(workspacePath).toBe('/tmp/worktrees/T-102');
+    expect(repoGit.fetch).toHaveBeenCalledWith('origin', 'main');
+    expect(repoGit.raw).toHaveBeenCalledWith(['worktree', 'add', '-b', 'feature/t-102-worktree', '/tmp/worktrees/T-102', 'origin/main']);
+    expect(worktreeGit.addConfig).toHaveBeenCalledWith('user.email', 'ai-factory@local');
+    expect(worktreeGit.addConfig).toHaveBeenCalledWith('user.name', 'AI Factory');
+    expect(rm).not.toHaveBeenCalled();
+  });
+
+  test('prepareTaskWorktree reuses a registered worktree and recreates stale task directories', async () => {
+    const repoGit = {
+      fetch: vi.fn(),
+      branchLocal: vi.fn(() => ({ all: ['main', 'feature/t-103-reuse'] })),
+      raw: vi.fn(async (args) => {
+        if (args[0] === 'worktree' && args[1] === 'list') {
+          return 'worktree /tmp/worktrees/T-103\nbranch refs/heads/feature/t-103-wrong\n\n';
+        }
+        return '';
+      }),
+      deleteLocalBranch: vi.fn(),
+    };
+    const worktreeGit = {
+      addConfig: vi.fn(),
+      branchLocal: vi.fn(() => ({ current: 'feature/t-103-reuse' })),
+    };
+    const simpleGitFactory = vi.fn((cwd) => {
+      if (cwd === '/repo/main-checkout') return repoGit;
+      if (cwd === '/tmp/worktrees/T-103') return worktreeGit;
+      throw new Error(`unexpected cwd ${cwd}`);
+    });
+    const existsSync = vi.fn((path) => path === '/tmp/worktrees' || path === '/tmp/worktrees/T-103');
+    const rm = vi.fn();
+
+    vi.doMock('./store.js', () => ({
+      default: {
+        updateTask: vi.fn(),
+        appendLog: vi.fn(),
+        appendSession: vi.fn(),
+        getTask: vi.fn(),
+        savePlan: vi.fn(),
+      },
+    }));
+    vi.doMock('./events.js', () => ({ default: { emit: vi.fn(), on: vi.fn() } }));
+    vi.doMock('./agents.js', () => ({
+      default: {
+        getAvailablePlanner: vi.fn(),
+        getAvailableImplementor: vi.fn(),
+        getAvailableReviewer: vi.fn(),
+        getAllStatus: vi.fn(() => []),
+        agents: new Map(),
+        getAgentsByRole: vi.fn(() => []),
+        get: vi.fn(),
+        removeAgent: vi.fn(),
+        scaleUp: vi.fn(),
+        reconfigure: vi.fn(),
+      },
+    }));
+    vi.doMock('./config.js', () => ({
+      loadSettings: vi.fn(() => ({ workspaceRoot: '/tmp/worktrees', maxReviewCycles: 3, agents: {} })),
+      getWorkspacesDir: vi.fn(() => '/tmp/worktrees'),
+    }));
+    vi.doMock('simple-git', () => ({
+      simpleGit: simpleGitFactory,
+    }));
+    vi.doMock('./workflow.js', () => ({
+      isReviewResultPlaceholder: vi.fn(() => false),
+      isPlanPlaceholder: vi.fn(() => false),
+      isImplementationPlaceholder: vi.fn(() => false),
+      parseReviewResult: vi.fn(() => ({ verdict: 'PASS', criticalIssues: [], minorIssues: [] })),
+      resolveTaskMaxReviewCycles: vi.fn((task, fallback = 3) => task?.maxReviewCycles || fallback),
+      reviewShouldPass: vi.fn(() => true),
+    }));
+    vi.doMock('./sessionHistory.js', () => ({
+      createSessionEntry: vi.fn(() => ({ id: 'session-1' })),
+    }));
+    vi.doMock('node:fs', async () => {
+      const actual = await vi.importActual('node:fs');
+      return {
+        ...actual,
+        existsSync,
+        mkdirSync: vi.fn(),
+        readFileSync: vi.fn(() => ''),
+        readdirSync: vi.fn(() => []),
+        unlinkSync: vi.fn(),
+      };
+    });
+    vi.doMock('node:fs/promises', () => ({ rm }));
+
+    const { prepareTaskWorktree } = await import('./orchestrator.js');
+    const task = {
+      id: 'T-103',
+      repoPath: '/repo/main-checkout',
+      branch: 'feature/t-103-reuse',
+    };
+
+    const workspacePath = await prepareTaskWorktree(task);
+
+    expect(workspacePath).toBe('/tmp/worktrees/T-103');
+    expect(rm).toHaveBeenCalledWith('/tmp/worktrees/T-103', expect.objectContaining({ recursive: true, force: true }));
+    expect(repoGit.deleteLocalBranch).toHaveBeenCalledWith('feature/t-103-reuse', true);
+    expect(repoGit.raw).toHaveBeenCalledWith(['worktree', 'add', '-b', 'feature/t-103-reuse', '/tmp/worktrees/T-103', 'origin/main']);
+  });
+});
+
+describe('prompt lifecycle wording', () => {
+  test('planner prompt does not require a task worktree before planning starts', () => {
+    const prompt = buildPlannerPrompt({
+      id: 'T-104',
+      title: 'Planning prompt',
+      description: '',
+      priority: 'medium',
+      repoPath: '/repo/main-checkout',
+      workspacePath: null,
+    });
+
+    expect(prompt).toContain('Repository: /repo/main-checkout');
+    expect(prompt).toContain('Workspace: planning runs in the repository checkout until implementation creates a task worktree.');
   });
 });

--- a/server/src/store.js
+++ b/server/src/store.js
@@ -239,7 +239,7 @@ class TaskStore {
   restartRecovery() {
     const recoveryMap = {
       planning: 'backlog',
-      workspace_setup: 'backlog',
+      workspace_setup: 'queued',
       queued: 'queued',
       implementing: 'queued',
       review: 'review',

--- a/server/src/store.js
+++ b/server/src/store.js
@@ -10,8 +10,8 @@ const TASKS_FILE = runtimePaths.tasksFile;
 const PLANS_DIR = runtimePaths.plansDir;
 
 function statusToStage(status) {
-  if (['workspace_setup', 'planning', 'awaiting_approval'].includes(status)) return 'planning';
-  if (['queued', 'implementing'].includes(status)) return 'implementation';
+  if (['planning', 'awaiting_approval'].includes(status)) return 'planning';
+  if (['workspace_setup', 'queued', 'implementing'].includes(status)) return 'implementation';
   if (status === 'review') return 'review';
   if (status === 'done' || status === 'awaiting_manual_pr') return 'done';
   if (['backlog', 'aborted'].includes(status)) return 'backlog';

--- a/server/src/workflow.js
+++ b/server/src/workflow.js
@@ -62,6 +62,7 @@ export function buildMaxReviewBlockerApprovalUpdate(task, now = new Date().toISO
     blockedReason: null,
     assignedTo: null,
     completedAt: task.completedAt || now,
+    workspacePath: null,
   };
 }
 

--- a/server/src/workflow.js
+++ b/server/src/workflow.js
@@ -61,7 +61,6 @@ export function buildMaxReviewBlockerApprovalUpdate(task, now = new Date().toISO
     status: 'done',
     blockedReason: null,
     assignedTo: null,
-    workspacePath: null,
     completedAt: task.completedAt || now,
   };
 }

--- a/server/src/workflow.test.js
+++ b/server/src/workflow.test.js
@@ -295,7 +295,7 @@ describe('retry status resolution', () => {
       blockedReason: null,
       assignedTo: null,
     });
-    expect(approved).not.toHaveProperty('workspacePath');
+    expect(approved.workspacePath).toBeNull();
     expect(typeof approved.completedAt).toBe('string');
     expect(extended).toEqual({
       status: 'queued',

--- a/server/src/workflow.test.js
+++ b/server/src/workflow.test.js
@@ -294,8 +294,8 @@ describe('retry status resolution', () => {
       status: 'done',
       blockedReason: null,
       assignedTo: null,
-      workspacePath: null,
     });
+    expect(approved).not.toHaveProperty('workspacePath');
     expect(typeof approved.completedAt).toBe('string');
     expect(extended).toEqual({
       status: 'queued',

--- a/server/src/worktree.js
+++ b/server/src/worktree.js
@@ -1,0 +1,18 @@
+/**
+ * Shared parser for `git worktree list --porcelain` output.
+ */
+export function parseWorktreeList(rawOutput) {
+  const worktrees = [];
+  if (typeof rawOutput !== 'string' || !rawOutput.trim()) return worktrees;
+
+  const blocks = rawOutput.trim().split('\n\n');
+  for (const block of blocks) {
+    const entry = {};
+    for (const line of block.split('\n')) {
+      if (line.startsWith('worktree ')) entry.path = line.slice('worktree '.length).trim();
+      if (line.startsWith('branch ')) entry.branchRef = line.slice('branch '.length).trim();
+    }
+    if (entry.path) worktrees.push(entry);
+  }
+  return worktrees;
+}

--- a/server/src/worktree.js
+++ b/server/src/worktree.js
@@ -5,10 +5,10 @@ export function parseWorktreeList(rawOutput) {
   const worktrees = [];
   if (typeof rawOutput !== 'string' || !rawOutput.trim()) return worktrees;
 
-  const blocks = rawOutput.trim().split('\n\n');
+  const blocks = rawOutput.trim().split(/\r?\n\r?\n/);
   for (const block of blocks) {
     const entry = {};
-    for (const line of block.split('\n')) {
+    for (const line of block.split(/\r?\n/)) {
       if (line.startsWith('worktree ')) entry.path = line.slice('worktree '.length).trim();
       if (line.startsWith('branch ')) entry.branchRef = line.slice('branch '.length).trim();
     }

--- a/server/src/worktree.test.js
+++ b/server/src/worktree.test.js
@@ -1,0 +1,67 @@
+import { describe, test, expect } from 'vitest';
+import { parseWorktreeList } from './worktree.js';
+
+describe('parseWorktreeList', () => {
+  test('parses standard porcelain output with paths and branches', () => {
+    const output = [
+      'worktree /repo/main',
+      'HEAD abc123',
+      'branch refs/heads/main',
+      '',
+      'worktree /tmp/workspaces/T-101',
+      'HEAD def456',
+      'branch refs/heads/feature/task-101',
+      '',
+    ].join('\n');
+
+    const result = parseWorktreeList(output);
+    expect(result).toEqual([
+      { path: '/repo/main', branchRef: 'refs/heads/main' },
+      { path: '/tmp/workspaces/T-101', branchRef: 'refs/heads/feature/task-101' },
+    ]);
+  });
+
+  test('handles detached HEAD entries (no branch line)', () => {
+    const output = [
+      'worktree /tmp/workspaces/T-200',
+      'HEAD abc123',
+      'detached',
+      '',
+    ].join('\n');
+
+    const result = parseWorktreeList(output);
+    expect(result).toEqual([{ path: '/tmp/workspaces/T-200' }]);
+    expect(result[0].branchRef).toBeUndefined();
+  });
+
+  test('handles bare worktree entries', () => {
+    const output = [
+      'worktree /repo/bare.git',
+      'bare',
+      '',
+    ].join('\n');
+
+    const result = parseWorktreeList(output);
+    expect(result).toEqual([{ path: '/repo/bare.git' }]);
+  });
+
+  test('returns empty array for empty string', () => {
+    expect(parseWorktreeList('')).toEqual([]);
+  });
+
+  test('returns empty array for null/undefined input', () => {
+    expect(parseWorktreeList(null)).toEqual([]);
+    expect(parseWorktreeList(undefined)).toEqual([]);
+  });
+
+  test('returns empty array for whitespace-only input', () => {
+    expect(parseWorktreeList('   \n  \n  ')).toEqual([]);
+  });
+
+  test('handles output without trailing newline', () => {
+    const output = 'worktree /repo/main\nbranch refs/heads/main';
+
+    const result = parseWorktreeList(output);
+    expect(result).toEqual([{ path: '/repo/main', branchRef: 'refs/heads/main' }]);
+  });
+});


### PR DESCRIPTION
## Summary

Replace per-task repository cloning with per-task Git worktrees and branches, while keeping planning in the configured repository checkout and updating cleanup/docs/tests around the new lifecycle.

## Key Changes

- server/src/orchestrator.js (replace clone-based workspace setup with git worktree creation/reuse/removal and move planning off task workspaces)
- server/src/index.js (adjust startup and task cleanup logic so it treats the workspace root as a worktree root and only removes safe orphan worktrees)
- server/src/config.js (keep existing configurable `workspaceRoot` behavior but update prompt/help text assumptions if they still describe cloned workspaces)
- server/src/orchestrator.pr.test.js (cover PR flow against worktree-backed repositories and any new git raw calls)
- server/src/orchestrator.delete.test.js (cover deletion/cleanup behavior for worktree-backed task directories)
- server/src/orchestrator.test.js (add focused unit coverage for branch/worktree preparation and planner cwd changes)

## Validation

- `server/src/orchestrator.test.js`: planning uses `task.repoPath` directly and does not create a workspace before approval
- `server/src/orchestrator.test.js`: implementation creates a branch-backed worktree under the configured workspace root and reuses it when valid
- `server/src/orchestrator.test.js`: stale/mismatched task directories are removed and recreated as worktrees
- `server/src/orchestrator.pr.test.js`: PR creation still fetches/rebases/pushes from the task worktree and manual-PR fallback remains intact
- `server/src/orchestrator.delete.test.js`: deleting/completing/resetting tasks removes the worktree safely and clears `workspacePath`
- `server/src/index.test.js`: startup orphan cleanup preserves active task worktrees and removes orphan task worktrees only
- `README.md` / `docs/task-flow.md`: no automated test, but verify wording matches actual lifecycle

## Review

- Verdict: PASS
- Summary: Changed files: server/src/orchestrator.js, server/src/index.js, server/src/config.js, server/src/orchestrator.test.js, server/src/orchestrator.pr.test.js, server/src/orchestrator.delete.test.js,
- Minor issues: (Confidence 82) cleanupOrphanTaskWorktrees in server/src/index.js:140-153 deletes orphan directories with rmSync without attempting git worktree remove first. If git worktree list --porcelain failed for a; (Confidence 78) parseWorktreeList is duplicated with slightly different return types: index.js:89 returns a Set of paths, orchestrator.js:640 returns an Array of {path, branchRef} objects. Both parse the

## Risks

- `git worktree add` fails if the target branch already exists and is checked out in another worktree; the implementation needs a clear reuse/error path instead of forcing branch deletion.
- Cleanup is more delicate than today because removing a worktree by deleting the directory can leave stale Git metadata behind; the plan should prefer `git worktree remove` and only force-delete as a fallback.
- Planning in `task.repoPath` assumes configured repos are valid local Git checkouts; if remote URLs are still allowed anywhere in the UI, the implementation may need an explicit validation/error path instead of relying on legacy blocker recovery.
- PR flow currently hardcodes `main` as the base branch; the worktree change should not expand scope into dependency-aware branching yet, but tests should make that constraint explicit.